### PR TITLE
[BE] feat/#49: 이슈 목록 조회 API 수정

### DIFF
--- a/BE/src/main/java/com/issuetracker/issue/application/IssueService.java
+++ b/BE/src/main/java/com/issuetracker/issue/application/IssueService.java
@@ -12,7 +12,10 @@ import com.issuetracker.issue.application.dto.IssueCreateInformation;
 import com.issuetracker.issue.application.dto.IssueLabelMappingInformation;
 import com.issuetracker.issue.application.dto.IssueSearchInputData;
 import com.issuetracker.issue.application.dto.IssueSearchInformation;
+import com.issuetracker.issue.application.dto.IssuesCountInformation;
 import com.issuetracker.issue.domain.IssueMapper;
+import com.issuetracker.issue.domain.IssuesCountData;
+import com.issuetracker.issue.infrastrucure.IssueRepository;
 import com.issuetracker.milestone.infrastructure.MilestoneRepository;
 import com.issuetracker.milestone.application.dto.MilestoneSearchInformation;
 import com.issuetracker.issue.infrastrucure.AuthorRepository;
@@ -28,6 +31,7 @@ public class IssueService {
 
 	private final IssueMapper issueMapper;
 	private final IssueCreator issueCreator;
+	private final IssueRepository issueRepository;
 	private final MilestoneRepository milestoneRepository;
 	private final AuthorRepository authorRepository;
 	private final AssigneeRepository assigneeRepository;
@@ -36,6 +40,10 @@ public class IssueService {
 	@Transactional(readOnly = true)
 	public List<IssueSearchInformation> search(IssueSearchInputData issueSearchData) {
 		return IssueSearchInformation.from(issueMapper.search(issueSearchData.toIssueSearch()));
+	}
+
+	public IssuesCountInformation getIssuesCount() {
+		return IssuesCountInformation.from(issueRepository.findAllCount());
 	}
 
 	public IssueCreateInformation create(IssueCreateInputData issueCreateData) {

--- a/BE/src/main/java/com/issuetracker/issue/application/dto/IssueSearchInformation.java
+++ b/BE/src/main/java/com/issuetracker/issue/application/dto/IssueSearchInformation.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.issuetracker.issue.domain.Issue;
+import com.issuetracker.issue.domain.IssuesCountData;
 import com.issuetracker.label.application.dto.LabelSearchInformation;
 import com.issuetracker.milestone.application.dto.MilestoneSearchInformation;
 

--- a/BE/src/main/java/com/issuetracker/issue/application/dto/IssuesCountInformation.java
+++ b/BE/src/main/java/com/issuetracker/issue/application/dto/IssuesCountInformation.java
@@ -1,0 +1,25 @@
+package com.issuetracker.issue.application.dto;
+
+import com.issuetracker.issue.domain.IssuesCountData;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class IssuesCountInformation {
+
+	private int issueOpenCount;
+	private int issueCloseCount;
+	private int labelCount;
+	private int milestoneCount;
+
+	public static IssuesCountInformation from(IssuesCountData issuesCountData) {
+		return new IssuesCountInformation(
+			issuesCountData.getIssueOpenCount(),
+			issuesCountData.getIssueCloseCount(),
+			issuesCountData.getLabelCount(),
+			issuesCountData.getMilestoneCount()
+		);
+	}
+}

--- a/BE/src/main/java/com/issuetracker/issue/domain/IssuesCountData.java
+++ b/BE/src/main/java/com/issuetracker/issue/domain/IssuesCountData.java
@@ -1,0 +1,22 @@
+package com.issuetracker.issue.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class IssuesCountData {
+
+	private int issueOpenCount;
+	private int issueCloseCount;
+	private int labelCount;
+	private int milestoneCount;
+
+	@Builder
+	public IssuesCountData(int issueCloseCount, int issueOpenCount, int labelCount, int milestoneCount) {
+		this.issueCloseCount = issueCloseCount;
+		this.issueOpenCount = issueOpenCount;
+		this.labelCount = labelCount;
+		this.milestoneCount = milestoneCount;
+	}
+}

--- a/BE/src/main/java/com/issuetracker/issue/infrastrucure/IssueRepository.java
+++ b/BE/src/main/java/com/issuetracker/issue/infrastrucure/IssueRepository.java
@@ -1,6 +1,9 @@
 package com.issuetracker.issue.infrastrucure;
 
+import java.util.Map;
+
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -8,11 +11,13 @@ import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
 import com.issuetracker.issue.domain.Issue;
+import com.issuetracker.issue.domain.IssuesCountData;
 
 @Repository
 public class IssueRepository {
 
 	private static final String SAVE_SQL = "INSERT INTO issue(title, content, is_open, create_at, milestone_id, author_id) VALUES(:title, :content, :isOpen, :createAt, :milestoneId, :authorId)";
+	private static final String FIND_ALL_COUNT_SQL = "SELECT SUM(CASE WHEN is_open = 0 THEN 1 ELSE 0 END) AS issue_close_count, SUM(CASE WHEN is_open = 1 THEN 1 ELSE 0 END) AS issue_open_count, (SELECT COUNT(id) FROM label) AS label_count, (SELECT COUNT(id) FROM milestone) AS milestone_count FROM issue";
 
 	private final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -33,4 +38,16 @@ public class IssueRepository {
 		jdbcTemplate.update(SAVE_SQL, param, keyHolder);
 		return keyHolder.getKey().longValue();
 	}
+
+	public IssuesCountData findAllCount() {
+		return jdbcTemplate.queryForObject(FIND_ALL_COUNT_SQL, Map.of(), ISSUE_MAIN_PAGE_COUNT_ROW_MAPPER);
+	}
+
+	private static final RowMapper<IssuesCountData> ISSUE_MAIN_PAGE_COUNT_ROW_MAPPER = (rs, rowNum) ->
+		IssuesCountData.builder()
+			.issueOpenCount(rs.getInt("issue_open_count"))
+			.issueCloseCount(rs.getInt("issue_close_count"))
+			.labelCount(rs.getInt("label_count"))
+			.milestoneCount(rs.getInt("milestone_count"))
+			.build();
 }

--- a/BE/src/main/java/com/issuetracker/issue/ui/IssueController.java
+++ b/BE/src/main/java/com/issuetracker/issue/ui/IssueController.java
@@ -33,7 +33,10 @@ public class IssueController {
 
 	@GetMapping
 	public ResponseEntity<IssuesSearchResponse> showIssues(@ModelAttribute IssueSearchRequest issueSearchRequest) {
-		IssuesSearchResponse issuesSearchResponse = IssuesSearchResponse.from(issueService.search(issueSearchRequest.toIssueSearchData(1L)));
+		IssuesSearchResponse issuesSearchResponse = IssuesSearchResponse.of(
+			issueService.getIssuesCount(),
+			issueService.search(issueSearchRequest.toIssueSearchData(1L))
+		);
 		return ResponseEntity.ok().body(issuesSearchResponse);
 	}
 

--- a/BE/src/main/java/com/issuetracker/issue/ui/dto/IssuesCountResponse.java
+++ b/BE/src/main/java/com/issuetracker/issue/ui/dto/IssuesCountResponse.java
@@ -1,0 +1,28 @@
+package com.issuetracker.issue.ui.dto;
+
+import com.issuetracker.issue.application.dto.IssuesCountInformation;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class IssuesCountResponse {
+
+	private int issueOpenCount;
+	private int issueCloseCount;
+	private int labelCount;
+	private int milestoneCount;
+
+	public static IssuesCountResponse from(IssuesCountInformation issuesCountInformation) {
+		return new IssuesCountResponse(
+			issuesCountInformation.getIssueOpenCount(),
+			issuesCountInformation.getIssueCloseCount(),
+			issuesCountInformation.getLabelCount(),
+			issuesCountInformation.getMilestoneCount()
+		);
+	}
+}

--- a/BE/src/main/java/com/issuetracker/issue/ui/dto/IssuesSearchResponse.java
+++ b/BE/src/main/java/com/issuetracker/issue/ui/dto/IssuesSearchResponse.java
@@ -3,6 +3,7 @@ package com.issuetracker.issue.ui.dto;
 import java.util.List;
 
 import com.issuetracker.issue.application.dto.IssueSearchInformation;
+import com.issuetracker.issue.application.dto.IssuesCountInformation;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -14,9 +15,13 @@ import lombok.NoArgsConstructor;
 @Getter
 public class IssuesSearchResponse {
 
+	private IssuesCountResponse metadata;
 	private List<IssueSearchResponse> issues;
 
-	public static IssuesSearchResponse from(List<IssueSearchInformation> issueSearchInformation) {
-		return new IssuesSearchResponse(IssueSearchResponse.from(issueSearchInformation));
+	public static IssuesSearchResponse of(IssuesCountInformation issuesCount, List<IssueSearchInformation> issueSearchInformation) {
+		return new IssuesSearchResponse(
+			IssuesCountResponse.from(issuesCount),
+			IssueSearchResponse.from(issueSearchInformation)
+		);
 	}
 }

--- a/BE/src/test/java/com/issuetracker/acceptance/IssueAcceptanceTest.java
+++ b/BE/src/test/java/com/issuetracker/acceptance/IssueAcceptanceTest.java
@@ -242,6 +242,16 @@ public class IssueAcceptanceTest extends AcceptanceTest {
 	}
 
 	private void 검색_조건에_맞는_이슈_목록_검증(ExtractableResponse<Response> response, IssueSearchRequest issueSearchRequest) {
+		int issueOpenCount = response.jsonPath().getInt("metadata.issueOpenCount");
+		int issueCloseCount = response.jsonPath().getInt("metadata.issueCloseCount");
+		int labelCount = response.jsonPath().getInt("metadata.labelCount");
+		int milestoneCount = response.jsonPath().getInt("metadata.milestoneCount");
+
+		assertThat(issueOpenCount).isEqualTo(6);
+		assertThat(issueCloseCount).isEqualTo(6);
+		assertThat(labelCount).isEqualTo(7);
+		assertThat(milestoneCount).isEqualTo(4);
+
 		if (issueSearchRequest.getIsOpen() != null) {
 			List<Boolean> isOpens = response.jsonPath().getList("issues.isOpen", Boolean.class);
 

--- a/BE/src/test/java/com/issuetracker/unit/repository/IssueRepositoryTest.java
+++ b/BE/src/test/java/com/issuetracker/unit/repository/IssueRepositoryTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import com.issuetracker.issue.domain.Issue;
+import com.issuetracker.issue.domain.IssuesCountData;
 import com.issuetracker.issue.infrastrucure.IssueRepository;
 import com.issuetracker.label.domain.Label;
 import com.issuetracker.member.domain.Member;
@@ -54,5 +55,17 @@ class IssueRepositoryTest {
 
 		// then
 		assertThat(issueId).isNotNull();
+	}
+
+	@Test
+	void 열린_이슈_닫힌_이슈_라벨_마일스톤_개수를_조회한다() {
+		// when
+		IssuesCountData actual = issueRepository.findAllCount();
+
+		// then
+		assertThat(actual.getIssueOpenCount()).isEqualTo(6);
+		assertThat(actual.getIssueCloseCount()).isEqualTo(6);
+		assertThat(actual.getLabelCount()).isEqualTo(7);
+		assertThat(actual.getMilestoneCount()).isEqualTo(4);
 	}
 }


### PR DESCRIPTION
## Key changes 🔑
- 이슈 목록 조회 시 열린 이슈, 닫힌 이슈, 라벨, 마일스톤 개수를 반환하게 추가