### PR TITLE
[Be] 이슈 목록 조회 및 생성 버그 수정

### DIFF
--- a/BE/src/main/java/com/issuetracker/config/IssueSearchArgumentResolver.java
+++ b/BE/src/main/java/com/issuetracker/config/IssueSearchArgumentResolver.java
@@ -1,0 +1,71 @@
+package com.issuetracker.config;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.issuetracker.config.exception.QueryStringKeyNotMatchException;
+import com.issuetracker.issue.ui.dto.IssueSearchRequest;
+
+@Component
+public class IssueSearchArgumentResolver implements HandlerMethodArgumentResolver {
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return IssueSearchRequest.class.isAssignableFrom(parameter.getParameterType());
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+		List<String> issueSearchRequestVariableNames = Arrays.stream(IssueSearchRequest.class.getDeclaredFields())
+			.map(Field::getName)
+			.collect(Collectors.toUnmodifiableList());
+
+		webRequest.getParameterMap()
+			.keySet()
+			.forEach(parameterName -> {
+				if (issueSearchRequestVariableNames.stream()
+					.noneMatch(variableName -> variableName.equals(parameterName))) {
+					throw new QueryStringKeyNotMatchException();
+				}
+		});
+
+		return new IssueSearchRequest(
+			Boolean.valueOf(webRequest.getParameter("isOpen")),
+			converterListLong(webRequest.getParameterValues("assigneeIds")),
+			converterListLong(webRequest.getParameterValues("labelIds")),
+			converterLong(webRequest.getParameter("milestoneId")),
+			converterLong(webRequest.getParameter("authorId")),
+			Boolean.valueOf(webRequest.getParameter("isCommentedByMe"))
+		);
+	}
+
+	private List<Long> converterListLong(String[] strings) {
+		if (strings == null || Arrays.stream(strings).allMatch(s -> s.equals(""))) {
+			return Collections.emptyList();
+		}
+
+		return Arrays.stream(strings)
+			.map(this::converterLong)
+			.filter(Objects::nonNull)
+			.collect(Collectors.toList());
+	}
+
+	private Long converterLong(String parameter) {
+		if (parameter == null || parameter.equals("")) {
+			return null;
+		}
+
+		return Long.valueOf(parameter);
+	}
+}

--- a/BE/src/main/java/com/issuetracker/config/WebConfig.java
+++ b/BE/src/main/java/com/issuetracker/config/WebConfig.java
@@ -1,12 +1,20 @@
 package com.issuetracker.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+	private final IssueSearchArgumentResolver issueSearchArgumentResolver;
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
@@ -17,5 +25,10 @@ public class WebConfig implements WebMvcConfigurer {
 				HttpMethod.PUT.name(), HttpMethod.PATCH.name(), HttpMethod.DELETE.name(),
 				HttpMethod.OPTIONS.name()
 			);
+	}
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(issueSearchArgumentResolver);
 	}
 }

--- a/BE/src/main/java/com/issuetracker/config/exception/QueryStringKeyNotMatchException.java
+++ b/BE/src/main/java/com/issuetracker/config/exception/QueryStringKeyNotMatchException.java
@@ -1,0 +1,12 @@
+package com.issuetracker.config.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class QueryStringKeyNotMatchException extends ApiException {
+
+	private static final String MESSAGE = "올바른 QueryString Key가 아닙니다.";
+
+	public QueryStringKeyNotMatchException() {
+		super(HttpStatus.BAD_REQUEST, MESSAGE);
+	}
+}

--- a/BE/src/main/java/com/issuetracker/issue/application/IssueCreator.java
+++ b/BE/src/main/java/com/issuetracker/issue/application/IssueCreator.java
@@ -43,7 +43,7 @@ public class IssueCreator {
 		labelValidator.verifyLabels(issueCreateData.getLabelIds());
 
 		return new IssueVerifiedCreator(
-			1L,
+			issueCreateData.getAuthor(),
 			issueCreateData.getAssigneeIds(),
 			issueCreateData.getLabelIds(),
 			issueCreateData.getMilestoneId()

--- a/BE/src/main/java/com/issuetracker/issue/application/dto/IssueCreateInputData.java
+++ b/BE/src/main/java/com/issuetracker/issue/application/dto/IssueCreateInputData.java
@@ -2,8 +2,6 @@ package com.issuetracker.issue.application.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 import com.issuetracker.issue.domain.Issue;
 import com.issuetracker.label.domain.Label;
@@ -26,8 +24,8 @@ public class IssueCreateInputData {
 		Long milestoneId, Long author) {
 		this.title = title;
 		this.content = content;
-		this.assigneeIds = getNonNullLabels(assigneeIds);
-		this.labelIds = getNonNullLabels(labelIds);
+		this.assigneeIds = assigneeIds;
+		this.labelIds = labelIds;
 		this.milestoneId = milestoneId;
 		this.author = author;
 	}
@@ -42,11 +40,5 @@ public class IssueCreateInputData {
 			.labels(labels)
 			.milestone(milestone)
 			.build();
-	}
-
-	private List<Long> getNonNullLabels(List<Long> ids) {
-		return ids.stream()
-			.filter(Objects::nonNull)
-			.collect(Collectors.toUnmodifiableList());
 	}
 }

--- a/BE/src/main/java/com/issuetracker/issue/ui/IssueController.java
+++ b/BE/src/main/java/com/issuetracker/issue/ui/IssueController.java
@@ -1,7 +1,9 @@
 package com.issuetracker.issue.ui;
 
 import java.net.URI;
+import java.util.List;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.issuetracker.issue.application.IssueService;
@@ -32,7 +35,7 @@ public class IssueController {
 	private final IssueService issueService;
 
 	@GetMapping
-	public ResponseEntity<IssuesSearchResponse> showIssues(@ModelAttribute IssueSearchRequest issueSearchRequest) {
+	public ResponseEntity<IssuesSearchResponse> showIssues(IssueSearchRequest issueSearchRequest) {
 		IssuesSearchResponse issuesSearchResponse = IssuesSearchResponse.of(
 			issueService.findIssuesCount(),
 			issueService.search(issueSearchRequest.toIssueSearchData(1L))

--- a/BE/src/main/java/com/issuetracker/issue/ui/dto/IssueCreateRequest.java
+++ b/BE/src/main/java/com/issuetracker/issue/ui/dto/IssueCreateRequest.java
@@ -1,6 +1,8 @@
 package com.issuetracker.issue.ui.dto;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotBlank;
 
@@ -35,10 +37,16 @@ public class IssueCreateRequest {
 		return new IssueCreateInputData(
 			title,
 			content,
-			assigneeIds,
-			labelIds,
+			converterNonNullList(assigneeIds),
+			converterNonNullList(labelIds),
 			milestoneId,
 			authorId
 		);
+	}
+
+	private List<Long> converterNonNullList(List<Long> ids) {
+		return ids.stream()
+			.filter(Objects::nonNull)
+			.collect(Collectors.toUnmodifiableList());
 	}
 }

--- a/BE/src/main/java/com/issuetracker/issue/ui/dto/IssueSearchRequest.java
+++ b/BE/src/main/java/com/issuetracker/issue/ui/dto/IssueSearchRequest.java
@@ -30,7 +30,7 @@ public class IssueSearchRequest {
 	}
 
 	private Long getCommentAuthorId(Long loginMemberId) {
-		if(isCommentedByMe == null || isCommentedByMe == Boolean.FALSE) {
+		if (isCommentedByMe == null || isCommentedByMe == Boolean.FALSE) {
 			return null;
 		}
 

--- a/BE/src/main/java/com/issuetracker/label/application/LabelValidator.java
+++ b/BE/src/main/java/com/issuetracker/label/application/LabelValidator.java
@@ -2,7 +2,6 @@ package com.issuetracker.label.application;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
@@ -22,16 +21,8 @@ public class LabelValidator {
 			return;
 		}
 
-		ids = getNonNullLabels(ids);
-
 		if (!labelRepository.existByIds(ids)) {
 			throw new LabelNotFoundException();
 		}
-	}
-
-	private List<Long> getNonNullLabels(List<Long> ids) {
-		return ids.stream()
-			.filter(Objects::nonNull)
-			.collect(Collectors.toUnmodifiableList());
 	}
 }

--- a/BE/src/main/java/com/issuetracker/member/application/MemberValidator.java
+++ b/BE/src/main/java/com/issuetracker/member/application/MemberValidator.java
@@ -2,7 +2,6 @@ package com.issuetracker.member.application;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
@@ -28,17 +27,9 @@ public class MemberValidator {
 			return;
 		}
 
-		ids = getNonNullLabels(ids);
-
 		if(!memberRepository.existByIds(ids)) {
 			throw new MemberNotFoundException();
 		}
-	}
-
-	private List<Long> getNonNullLabels(List<Long> ids) {
-		return ids.stream()
-			.filter(Objects::nonNull)
-			.collect(Collectors.toUnmodifiableList());
 	}
 }
 

--- a/BE/src/main/resources/mapper/IssueMapper.xml
+++ b/BE/src/main/resources/mapper/IssueMapper.xml
@@ -45,12 +45,12 @@
                 label.color as label_color
         FROM issue issue
         INNER JOIN member author ON author.id = issue.author_id
-        LEFT OUTER JOIN milestone milestone ON issue.milestone_id = milestone.id
-        LEFT OUTER JOIN issue_label_mapping issue_label_mapping ON issue.id = issue_label_mapping.issue_id
-        LEFT OUTER JOIN label label ON issue_label_mapping.label_id = label.id
-        LEFT OUTER JOIN assignee assignee ON issue.id = assignee.issue_id
-        LEFT OUTER JOIN member assignee_member ON assignee.member_id = assignee_member.id
-        LEFT OUTER JOIN issue_comment issue_comment ON issue.id = issue_comment.issue_id
+        LEFT OUTER JOIN milestone ON issue.milestone_id = milestone.id
+        LEFT OUTER JOIN issue_label_mapping ON issue.id = issue_label_mapping.issue_id
+        LEFT OUTER JOIN label ON issue_label_mapping.label_id = label.id
+        LEFT OUTER JOIN assignee ON issue.id = assignee.issue_id
+        LEFT OUTER JOIN member ON assignee.member_id = member.id
+        LEFT OUTER JOIN issue_comment ON issue.id = issue_comment.issue_id
         <where>
             <if test="isOpen != null">
                 <trim prefix="AND">
@@ -59,19 +59,32 @@
             </if>
             <if test="assigneeIds != null and assigneeIds.size() > 0">
                 <trim prefix="AND">
-                    assignee.member_id IN
+                    issue.id IN (
+                        SELECT issue_id
+                        FROM assignee
+                        WHERE member_id IN
+                        <foreach collection="assigneeIds" item="assigneeId" separator="," open="(" close=")">
+                            #{assigneeId}
+                        </foreach>
+                        GROUP BY issue_id
+                        HAVING COUNT(DISTINCT member_id) = ${assigneeIds.size}
+                    )
                 </trim>
-                <foreach collection="assigneeIds" item="assigneeId" separator="," open="(" close=")">
-                    #{assigneeId}
-                </foreach>
             </if>
             <if test="labelIds != null and labelIds.size() > 0">
                 <trim prefix="AND">
-                    issue_label_mapping.label_id IN
+                    issue.id IN (
+                        SELECT issue_id
+                        FROM issue_label_mapping
+                        WHERE label_id IN
+                        <foreach collection="labelIds" item="labelId" separator="," open="(" close=")">
+                            #{labelId}
+                        </foreach>
+                        GROUP BY issue_id
+                        HAVING COUNT(DISTINCT label_id) = ${labelIds.size}
+                    )
                 </trim>
-                <foreach collection="labelIds" item="labelId" separator="," open="(" close=")">
-                    #{labelId}
-                </foreach>
+
             </if>
             <if test="milestoneId != null">
                 <trim prefix="AND">
@@ -89,6 +102,6 @@
                 </trim>
             </if>
         </where>
-        ORDER BY issue.id, label.id
+        ORDER BY issue.id desc, label.id
     </select>
 </mapper>

--- a/BE/src/test/java/com/issuetracker/unit/infrastrucure/IssueMapperTest.java
+++ b/BE/src/test/java/com/issuetracker/unit/infrastrucure/IssueMapperTest.java
@@ -8,6 +8,7 @@ import static com.issuetracker.util.fixture.MilestoneFixture.MILESTONR1;
 import static com.issuetracker.util.fixture.MilestoneFixture.MILESTONR3;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -44,7 +45,7 @@ public class IssueMapperTest {
 		// given
 		IssueSearch issueSearch = IssueSearch.builder()
 			.isOpen(true)
-			.assigneeIds(null)
+			.assigneeIds(Collections.emptyList())
 			.labelIds(List.of(LABEL5.getId()))
 			.milestoneId(MILESTONR1.getId())
 			.authorId(USER1.getId())
@@ -63,7 +64,7 @@ public class IssueMapperTest {
 		// given
 		IssueSearch issueSearch = IssueSearch.builder()
 			.isOpen(false)
-			.assigneeIds(null)
+			.assigneeIds(Collections.emptyList())
 			.labelIds(List.of(LABEL1.getId()))
 			.milestoneId(MILESTONR3.getId())
 			.authorId(USER4.getId())

--- a/BE/src/test/java/com/issuetracker/util/steps/IssueSteps.java
+++ b/BE/src/test/java/com/issuetracker/util/steps/IssueSteps.java
@@ -29,6 +29,14 @@ public class IssueSteps {
 			.then().log().all().extract();
 	}
 
+	public static ExtractableResponse<Response> 이슈_목록_조회_요청(Map<String, Object> params) {
+		return RestAssured.given().log().all()
+			.queryParams(params)
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+			.when().get("/api/issues")
+			.then().log().all().extract();
+	}
+
 	public static ExtractableResponse<Response> 이슈_작성_요청(IssueCreateRequest issueCreateRequest) {
 		return RestAssured.given().log().all()
 			.body(issueCreateRequest)


### PR DESCRIPTION
## Key changes 🔑
- 이슈 목록 조회 시 다수의 라벨이나, 다수의 작성자를 선택 시
   이슈가 해당 라벨들이나 작성자들을 동시에 갖고 있지 않는 버그 수정
- 이슈 목록 조회 시 검색 조건이 아닌 경우 400 반환하게 수정
- 이슈 생성 시 제목이나 내용에서 최대 길이가 초과될 경우 에러 메시지가 복잡하게 되어 있어 수정