### PR TITLE
[BE] fix/#136: 이슈 상세 조회 시 댓글 생성 날짜 null인 현상 수정

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -36,6 +36,6 @@ dependencies {
 	testImplementation 'io.rest-assured:rest-assured:4.5.1'
 }
 
-tasks.named('test') {
+test {
 	useJUnitPlatform()
 }

--- a/BE/src/main/resources/mapper/IssueMapper.xml
+++ b/BE/src/main/resources/mapper/IssueMapper.xml
@@ -34,6 +34,7 @@
         <id property="id" column="issue_comment_id" />
         <result property="content" column="issue_comment_content" />
         <result property="description" column="issue_comment_description" />
+        <result property="createAt" column="issue_comment_create_at"/>
         <association property="author" column="issue_comment_author" javaType="Member">
             <id property="id" column="issue_comment_author_id" />
             <result property="nickname" column="issue_comment_author_nickname" />


### PR DESCRIPTION
## Key changes 🔑
- 이슈 상세 조회 시 댓글 생성 날짜 null인 현상 수정