### PR TITLE
[DEV] BE version 0.3.1 버그 수정

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -36,6 +36,6 @@ dependencies {
 	testImplementation 'io.rest-assured:rest-assured:4.5.1'
 }
 
-tasks.named('test') {
+test {
 	useJUnitPlatform()
 }

--- a/BE/src/main/java/com/issuetracker/config/WebConfig.java
+++ b/BE/src/main/java/com/issuetracker/config/WebConfig.java
@@ -20,6 +20,7 @@ public class WebConfig implements WebMvcConfigurer {
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
 			.allowedOrigins("http://3.34.141.196")
+			.allowedOrigins("http://localhost:5173", "http://localhost:5174")
 			.allowedMethods(
 				HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PUT.name(),
 				HttpMethod.PATCH.name(), HttpMethod.DELETE.name(), HttpMethod.OPTIONS.name()

--- a/BE/src/main/java/com/issuetracker/issue/infrastrucure/JdbcAssignedLabelRepository.java
+++ b/BE/src/main/java/com/issuetracker/issue/infrastrucure/JdbcAssignedLabelRepository.java
@@ -21,20 +21,24 @@ public class JdbcAssignedLabelRepository implements AssignedLabelRepository {
 
 	private static final String SAVE_SQL = "INSERT INTO assigned_label(issue_id, label_id) VALUES(:issueId, :labelId)";
 	private static final String DELETE_SQL = "DELETE FROM assigned_label WHERE id = :id";
-	private static final String FIND_ALL_SEARCH_SQL = "SELECT DISTINCT label.id, label.title, label.color, label.description FROM label INNER JOIN assigned_label ON label.id = assigned_label.label_id ORDER BY label.id";
+	private static final String FIND_ALL_SEARCH_SQL = "SELECT DISTINCT label.id, label.title, label.color, label.description FROM label INNER JOIN assigned_label ON label.id = assigned_label.label_id WHERE label.is_deleted = 0 ORDER BY label.id";
 	private static final String FIND_ALL_ASSIGNED_TO_ISSUE
 		= "SELECT label.id, label.title, label.color, label.description "
 		+ "FROM assigned_label "
 		+ "LEFT JOIN label "
 		+ "ON assigned_label.label_id = label.id "
-		+ "WHERE assigned_label.issue_id = :issueId";
+		+ "WHERE assigned_label.issue_id = :issueId "
+		+ "AND label.is_deleted = false "
+		+ "ORDER BY label.title ";
 	private static final String FIND_ALL_UNASSIGNED_TO_ISSUE
 		= "SELECT label.id, label.title, label.color, label.description "
 		+ "FROM label "
-		+ "WHERE label.id NOT IN( "
+		+ "WHERE label.is_deleted = false "
+		+ "AND label.id NOT IN( "
 		+ "    SELECT assigned_label.label_id "
 		+ "    FROM assigned_label "
-		+ "    WHERE assigned_label.issue_id = :issueId)";
+		+ "    WHERE assigned_label.issue_id = :issueId) "
+		+ "ORDER BY label.title ";
 
 	private final NamedParameterJdbcTemplate jdbcTemplate;
 

--- a/BE/src/main/java/com/issuetracker/issue/infrastrucure/JdbcIssueRepository.java
+++ b/BE/src/main/java/com/issuetracker/issue/infrastrucure/JdbcIssueRepository.java
@@ -1,9 +1,7 @@
 package com.issuetracker.issue.infrastrucure;
 
 import java.util.Map;
-import java.util.Optional;
 
-import org.springframework.dao.support.DataAccessUtils;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
@@ -22,13 +20,13 @@ import com.issuetracker.issue.domain.IssuesCountData;
 public class JdbcIssueRepository implements IssueRepository {
 
 	private static final String SAVE_SQL = "INSERT INTO issue(title, content, is_open, create_at, milestone_id, author_id) VALUES(:title, :content, :isOpen, :createAt, :milestoneId, :authorId)";
-	private static final String FIND_ALL_COUNT_SQL = "SELECT SUM(CASE WHEN is_open = 0 THEN 1 ELSE 0 END) AS issue_close_count, SUM(CASE WHEN is_open = 1 THEN 1 ELSE 0 END) AS issue_open_count, (SELECT COUNT(id) FROM label) AS label_count, (SELECT COUNT(id) FROM milestone) AS milestone_count FROM issue";
+	private static final String FIND_ALL_COUNT_SQL = "SELECT SUM(CASE WHEN is_open = false THEN true ELSE false END) AS issue_close_count, SUM(CASE WHEN is_open = 1 THEN 1 ELSE 0 END) AS issue_open_count, (SELECT COUNT(id) FROM label WHERE label.is_deleted = false) AS label_count, (SELECT COUNT(id) FROM milestone WHERE milestone.is_deleted = false) AS milestone_count FROM issue WHERE issue.is_deleted = false";
 	private static final String UPDATE_IS_OPEN_SQL = "UPDATE issue SET is_open = :isOpen WHERE id = :id";
 	private static final String UPDATE_TITLE_SQL = "UPDATE issue SET title = :title WHERE id = :id";
 	private static final String UPDATE_CONTENT_SQL = "UPDATE issue SET content = :content WHERE id = :id";
 	private static final String UPDATE_MILESTONE_SQL = "UPDATE issue SET milestone_id = :milestoneId WHERE id = :id";
-	private static final String DELETE_SQL = "UPDATE issue SET is_deleted = 1 WHERE id = :id";
-	private static final String EXIST_BY_ID_SQL = "SELECT EXISTS(SELECT 1 FROM issue WHERE id = :id)";
+	private static final String DELETE_SQL = "UPDATE issue SET is_deleted = true WHERE id = :id";
+	private static final String EXIST_BY_ID_SQL = "SELECT EXISTS(SELECT 1 FROM issue WHERE id = :id AND is_deleted = false)";
 
 	private final NamedParameterJdbcTemplate jdbcTemplate;
 

--- a/BE/src/main/java/com/issuetracker/issue/ui/dto/IssueCreateRequest.java
+++ b/BE/src/main/java/com/issuetracker/issue/ui/dto/IssueCreateRequest.java
@@ -1,5 +1,6 @@
 package com.issuetracker.issue.ui.dto;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -16,7 +17,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Getter
 public class IssueCreateRequest {
 
@@ -33,18 +33,31 @@ public class IssueCreateRequest {
 
 	private Long milestoneId;
 
+	public IssueCreateRequest(String title, String content, List<Long> assigneeIds, List<Long> labelIds,
+		Long milestoneId) {
+		this.title = title;
+		this.content = content;
+		this.assigneeIds = converterNonNullList(assigneeIds);
+		this.labelIds = converterNonNullList(labelIds);
+		this.milestoneId = milestoneId;
+	}
+
 	public IssueCreateInputData toIssueCreateData(Long authorId) {
 		return new IssueCreateInputData(
 			title,
 			content,
-			converterNonNullList(assigneeIds),
-			converterNonNullList(labelIds),
+			assigneeIds,
+			labelIds,
 			milestoneId,
 			authorId
 		);
 	}
 
 	private List<Long> converterNonNullList(List<Long> ids) {
+		if (Objects.isNull(ids)) {
+			ids = Collections.emptyList();
+		}
+
 		return ids.stream()
 			.filter(Objects::nonNull)
 			.collect(Collectors.toUnmodifiableList());

--- a/BE/src/main/java/com/issuetracker/label/application/LabelService.java
+++ b/BE/src/main/java/com/issuetracker/label/application/LabelService.java
@@ -1,17 +1,17 @@
 package com.issuetracker.label.application;
 
-import java.util.List;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.issuetracker.config.exception.CustomHttpException;
 import com.issuetracker.config.exception.ErrorType;
+import com.issuetracker.label.application.dto.LabelCountMetadataInformation;
 import com.issuetracker.label.application.dto.LabelCreateInformation;
 import com.issuetracker.label.application.dto.LabelCreateInputData;
 import com.issuetracker.label.application.dto.LabelDeleteInputData;
 import com.issuetracker.label.application.dto.LabelInformation;
 import com.issuetracker.label.application.dto.LabelUpdateInputData;
+import com.issuetracker.label.application.dto.LabelsInformation;
 import com.issuetracker.label.domain.LabelRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -47,7 +47,11 @@ public class LabelService {
 		}
 	}
 
-	public List<LabelInformation> search() {
-		return LabelInformation.from(labelRepository.findAll());
+	public LabelsInformation search() {
+
+		return LabelsInformation.from(
+			LabelCountMetadataInformation.from(labelRepository.calculateMetadata()),
+			LabelInformation.from(labelRepository.findAll())
+		);
 	}
 }

--- a/BE/src/main/java/com/issuetracker/label/application/dto/LabelCountMetadataInformation.java
+++ b/BE/src/main/java/com/issuetracker/label/application/dto/LabelCountMetadataInformation.java
@@ -1,0 +1,21 @@
+package com.issuetracker.label.application.dto;
+
+import com.issuetracker.label.domain.LabelCountMetadata;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class LabelCountMetadataInformation {
+
+	private int totalLabelCount;
+	private int totalMilestoneCount;
+
+	public static LabelCountMetadataInformation from(LabelCountMetadata metadata) {
+		return new LabelCountMetadataInformation(
+			metadata.getTotalLabelCount(),
+			metadata.getTotalMilestoneCount()
+		);
+	}
+}

--- a/BE/src/main/java/com/issuetracker/label/application/dto/LabelsInformation.java
+++ b/BE/src/main/java/com/issuetracker/label/application/dto/LabelsInformation.java
@@ -1,0 +1,21 @@
+package com.issuetracker.label.application.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class LabelsInformation {
+
+	private LabelCountMetadataInformation metadata;
+	private List<LabelInformation> labels;
+
+	public static LabelsInformation from(LabelCountMetadataInformation metadata, List<LabelInformation> labels) {
+		return new LabelsInformation(
+			metadata,
+			labels
+		);
+	}
+}

--- a/BE/src/main/java/com/issuetracker/label/domain/LabelCountMetadata.java
+++ b/BE/src/main/java/com/issuetracker/label/domain/LabelCountMetadata.java
@@ -1,0 +1,17 @@
+package com.issuetracker.label.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class LabelCountMetadata {
+
+	private int totalLabelCount;
+	private int totalMilestoneCount;
+
+	@Builder
+	public LabelCountMetadata(int totalLabelCount, int totalMilestoneCount) {
+		this.totalLabelCount = totalLabelCount;
+		this.totalMilestoneCount = totalMilestoneCount;
+	}
+}

--- a/BE/src/main/java/com/issuetracker/label/domain/LabelRepository.java
+++ b/BE/src/main/java/com/issuetracker/label/domain/LabelRepository.java
@@ -15,4 +15,6 @@ public interface LabelRepository {
 	List<Label> findAll();
 
 	boolean existById(Long id);
+
+	LabelCountMetadata calculateMetadata();
 }

--- a/BE/src/main/java/com/issuetracker/label/infrastructure/JdbcLabelRepository.java
+++ b/BE/src/main/java/com/issuetracker/label/infrastructure/JdbcLabelRepository.java
@@ -18,12 +18,12 @@ import com.issuetracker.label.domain.LabelRepository;
 @Repository
 public class JdbcLabelRepository implements LabelRepository {
 
-	private static final String EXIST_BY_ID_SQL = "SELECT EXISTS(SELECT 1 FROM label WHERE id = :id)";
-	private static final String EXIST_BY_IDS_SQL = "SELECT IF(COUNT(id) = :size, TRUE, FALSE) FROM label WHERE id IN(:labelIds)";
+	private static final String EXIST_BY_ID_SQL = "SELECT EXISTS(SELECT 1 FROM label WHERE id = :id AND is_deleted = false)";
+	private static final String EXIST_BY_IDS_SQL = "SELECT IF(COUNT(id) = :size, TRUE, FALSE) FROM label WHERE is_deleted = false AND id IN(:labelIds)";
 	private static final String SAVE_SQL = "INSERT INTO label(title, description, color) VALUE(:title, :description, :color)";
 	private static final String UPDATE_SQL = "UPDATE label SET title = :title, description = :description, color = :color WHERE id = :id";
 	private static final String DELETE_SQL = "UPDATE label SET is_deleted = true WHERE id = :id";
-	private static final String FIND_ALL_SQL = "SELECT id, title, description, color FROM label WHERE is_deleted = false";
+	private static final String FIND_ALL_SQL = "SELECT id, title, description, color FROM label WHERE is_deleted = false ORDER BY id desc";
 
 	private final NamedParameterJdbcTemplate jdbcTemplate;
 

--- a/BE/src/main/java/com/issuetracker/label/ui/dto/LabelCountMetadataResponse.java
+++ b/BE/src/main/java/com/issuetracker/label/ui/dto/LabelCountMetadataResponse.java
@@ -1,0 +1,24 @@
+package com.issuetracker.label.ui.dto;
+
+import com.issuetracker.label.application.dto.LabelCountMetadataInformation;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class LabelCountMetadataResponse {
+
+	private int totalLabelCount;
+	private int totalMilestoneCount;
+
+	public static LabelCountMetadataResponse from(LabelCountMetadataInformation metadataInformation) {
+		return new LabelCountMetadataResponse(
+			metadataInformation.getTotalLabelCount(),
+			metadataInformation.getTotalMilestoneCount()
+		);
+	}
+}

--- a/BE/src/main/java/com/issuetracker/label/ui/dto/LabelsResponse.java
+++ b/BE/src/main/java/com/issuetracker/label/ui/dto/LabelsResponse.java
@@ -2,7 +2,7 @@ package com.issuetracker.label.ui.dto;
 
 import java.util.List;
 
-import com.issuetracker.label.application.dto.LabelInformation;
+import com.issuetracker.label.application.dto.LabelsInformation;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -14,9 +14,13 @@ import lombok.NoArgsConstructor;
 @Getter
 public class LabelsResponse {
 
+	private LabelCountMetadataResponse metadata;
 	private List<LabelResponse> labels;
 
-	public static LabelsResponse from(List<LabelInformation> labelInformations) {
-		return new LabelsResponse(LabelResponse.from(labelInformations));
+	public static LabelsResponse from(LabelsInformation labelsInformation) {
+		return new LabelsResponse(
+			LabelCountMetadataResponse.from(labelsInformation.getMetadata()),
+			LabelResponse.from(labelsInformation.getLabels())
+		);
 	}
 }

--- a/BE/src/main/java/com/issuetracker/milestone/application/MilestoneService.java
+++ b/BE/src/main/java/com/issuetracker/milestone/application/MilestoneService.java
@@ -8,13 +8,16 @@ import org.springframework.transaction.annotation.Transactional;
 import com.issuetracker.config.exception.CustomHttpException;
 import com.issuetracker.config.exception.ErrorType;
 import com.issuetracker.milestone.application.dto.MilestoneCandidatesInformation;
+import com.issuetracker.milestone.application.dto.MilestoneCountMetadataInformation;
 import com.issuetracker.milestone.application.dto.MilestoneCreateInformation;
 import com.issuetracker.milestone.application.dto.MilestoneCreateInputData;
 import com.issuetracker.milestone.application.dto.MilestoneDeleteInputData;
 import com.issuetracker.milestone.application.dto.MilestoneInformation;
+import com.issuetracker.milestone.application.dto.MilestoneSearchByOpenStatusInputData;
 import com.issuetracker.milestone.application.dto.MilestoneSearchInformation;
 import com.issuetracker.milestone.application.dto.MilestoneUpdateInputData;
 import com.issuetracker.milestone.application.dto.MilestoneUpdateOpenStatusInputData;
+import com.issuetracker.milestone.application.dto.MilestonesInformation;
 import com.issuetracker.milestone.domain.MilestoneRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -64,8 +67,13 @@ public class MilestoneService {
 		}
 	}
 
-	public List<MilestoneInformation> search() {
-		return MilestoneInformation.from(milestoneRepository.findAll());
+	public MilestonesInformation search(
+		MilestoneSearchByOpenStatusInputData milestoneSearchByOpenStatusInputData) {
+		return MilestonesInformation.from(
+			MilestoneCountMetadataInformation.from(milestoneRepository.calculateMetadata()),
+			MilestoneInformation.from(
+				milestoneRepository.findAll(milestoneSearchByOpenStatusInputData.toMilestoneForSearchByOpenStatus()))
+		);
 	}
 
 	public MilestoneCandidatesInformation searchMilestoneCandidates(long issueId) {

--- a/BE/src/main/java/com/issuetracker/milestone/application/dto/IssueDetailMilestoneInformation.java
+++ b/BE/src/main/java/com/issuetracker/milestone/application/dto/IssueDetailMilestoneInformation.java
@@ -16,7 +16,7 @@ public class IssueDetailMilestoneInformation {
 
 	private Long id;
 	private String title;
-	private Double progress;
+	private Integer progress;
 
 	public static IssueDetailMilestoneInformation from(Milestone milestone) {
 		if (Objects.isNull(milestone)) {

--- a/BE/src/main/java/com/issuetracker/milestone/application/dto/MilestoneCountMetadataInformation.java
+++ b/BE/src/main/java/com/issuetracker/milestone/application/dto/MilestoneCountMetadataInformation.java
@@ -1,0 +1,25 @@
+package com.issuetracker.milestone.application.dto;
+
+import com.issuetracker.milestone.domain.MilestoneCountMetadata;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class MilestoneCountMetadataInformation {
+
+	private int totalLabelCount;
+	private int totalMilestoneCount;
+	private int openMilestoneCount;
+	private int closeMilestoneCount;
+
+	public static MilestoneCountMetadataInformation from(MilestoneCountMetadata metadata) {
+		return new MilestoneCountMetadataInformation(
+			metadata.getTotalLabelCount(),
+			metadata.getTotalMilestoneCount(),
+			metadata.getOpenMilestoneCount(),
+			metadata.getCloseMilestoneCount()
+		);
+	}
+}

--- a/BE/src/main/java/com/issuetracker/milestone/application/dto/MilestoneInformation.java
+++ b/BE/src/main/java/com/issuetracker/milestone/application/dto/MilestoneInformation.java
@@ -18,7 +18,7 @@ public class MilestoneInformation {
 	private String description;
 	private LocalDate deadline;
 	private boolean isOpen;
-	private Double progress;
+	private Integer progress;
 
 	public static MilestoneInformation from(Milestone milestone) {
 		return new MilestoneInformation(

--- a/BE/src/main/java/com/issuetracker/milestone/application/dto/MilestoneSearchByOpenStatusInputData.java
+++ b/BE/src/main/java/com/issuetracker/milestone/application/dto/MilestoneSearchByOpenStatusInputData.java
@@ -1,0 +1,19 @@
+package com.issuetracker.milestone.application.dto;
+
+import com.issuetracker.milestone.domain.Milestone;
+
+public class MilestoneSearchByOpenStatusInputData {
+
+	private boolean isOpen;
+
+	public MilestoneSearchByOpenStatusInputData(boolean isOpen) {
+		this.isOpen = isOpen;
+	}
+
+	public Milestone toMilestoneForSearchByOpenStatus() {
+		return Milestone.builder()
+			.isOpen(isOpen)
+			.build();
+	}
+}
+

--- a/BE/src/main/java/com/issuetracker/milestone/application/dto/MilestonesInformation.java
+++ b/BE/src/main/java/com/issuetracker/milestone/application/dto/MilestonesInformation.java
@@ -1,0 +1,22 @@
+package com.issuetracker.milestone.application.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class MilestonesInformation {
+
+	private MilestoneCountMetadataInformation metadata;
+	private List<MilestoneInformation> milestones;
+
+	public static MilestonesInformation from(MilestoneCountMetadataInformation metadata,
+		List<MilestoneInformation> milestones) {
+		return new MilestonesInformation(
+			metadata,
+			milestones
+		);
+	}
+}

--- a/BE/src/main/java/com/issuetracker/milestone/domain/Milestone.java
+++ b/BE/src/main/java/com/issuetracker/milestone/domain/Milestone.java
@@ -17,10 +17,10 @@ public class Milestone {
 	private String description;
 	private LocalDate deadline;
 	private boolean isOpen;
-	private Double progress;
+	private Integer progress;
 
 	@Builder
-	public Milestone(Long id, String title, String description, LocalDate deadline, boolean isOpen, Double progress) {
+	public Milestone(Long id, String title, String description, LocalDate deadline, boolean isOpen, Integer progress) {
 		this.id = id;
 		this.title = title;
 		this.description = description;
@@ -30,7 +30,7 @@ public class Milestone {
 	}
 
 	@Builder
-	public Milestone(Long id, String title, String description, String deadline, boolean isOpen, Double progress) {
+	public Milestone(Long id, String title, String description, String deadline, boolean isOpen, Integer progress) {
 		this.id = id;
 		this.title = title;
 		this.description = description;

--- a/BE/src/main/java/com/issuetracker/milestone/domain/MilestoneCountMetadata.java
+++ b/BE/src/main/java/com/issuetracker/milestone/domain/MilestoneCountMetadata.java
@@ -1,0 +1,22 @@
+package com.issuetracker.milestone.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MilestoneCountMetadata {
+
+	private int totalLabelCount;
+	private int totalMilestoneCount;
+	private int openMilestoneCount;
+	private int closeMilestoneCount;
+
+	@Builder
+	public MilestoneCountMetadata(int totalLabelCount, int totalMilestoneCount, int openMilestoneCount,
+		int closeMilestoneCount) {
+		this.totalLabelCount = totalLabelCount;
+		this.totalMilestoneCount = totalMilestoneCount;
+		this.openMilestoneCount = openMilestoneCount;
+		this.closeMilestoneCount = closeMilestoneCount;
+	}
+}

--- a/BE/src/main/java/com/issuetracker/milestone/domain/MilestoneRepository.java
+++ b/BE/src/main/java/com/issuetracker/milestone/domain/MilestoneRepository.java
@@ -16,9 +16,11 @@ public interface MilestoneRepository {
 
 	int delete(Milestone milestone);
 
-	List<Milestone> findAll();
+	List<Milestone> findAll(Milestone milestone);
 
 	List<Milestone> findAllAssignedToIssue(long issueId);
 
 	List<Milestone> findAllUnassignedToIssue(long issueId);
+
+	MilestoneCountMetadata calculateMetadata();
 }

--- a/BE/src/main/java/com/issuetracker/milestone/infrastructure/JdbcMilestoneRepository.java
+++ b/BE/src/main/java/com/issuetracker/milestone/infrastructure/JdbcMilestoneRepository.java
@@ -20,8 +20,6 @@ import com.issuetracker.milestone.domain.MilestoneRepository;
 @Repository
 public class JdbcMilestoneRepository implements MilestoneRepository {
 
-	private static final String EXIST_BY_ID_SQL = "SELECT EXISTS(SELECT 1 FROM milestone WHERE id = :id)";
-	private static final String FIND_ALL_FOR_FILTER = "SELECT id, title FROM milestone ORDER BY is_open DESC";
 	private static final String EXIST_BY_ID_SQL = "SELECT EXISTS(SELECT 1 FROM milestone WHERE is_deleted = false AND id = :id)";
 	private static final String FIND_ALL_FOR_FILTER = "SELECT id, title FROM milestone WHERE milestone.is_deleted = false ORDER BY is_open DESC";
 	private static final String SAVE_SQL = "INSERT INTO milestone(title, description, deadline, is_open) VALUE(:title, :description, :deadline, true)";
@@ -41,7 +39,7 @@ public class JdbcMilestoneRepository implements MilestoneRepository {
 		+ "ON milestone.id = issue.milestone_id "
 		+ "WHERE milestone.is_deleted = false "
 		+ "AND milestone.is_open = :isOpen "
-		+ "GROUP BY milestone.id"
+		+ "GROUP BY milestone.id "
 		+ "ORDER BY milestone.id DESC ";
 	private static final String FIND_ALL_ASSIGNED_TO_ISSUE
 		= "SELECT "

--- a/BE/src/main/java/com/issuetracker/milestone/infrastructure/JdbcMilestoneRepository.java
+++ b/BE/src/main/java/com/issuetracker/milestone/infrastructure/JdbcMilestoneRepository.java
@@ -19,8 +19,8 @@ import com.issuetracker.milestone.domain.MilestoneRepository;
 @Repository
 public class JdbcMilestoneRepository implements MilestoneRepository {
 
-	private static final String EXIST_BY_ID_SQL = "SELECT EXISTS(SELECT 1 FROM milestone WHERE id = :id)";
-	private static final String FIND_ALL_FOR_FILTER = "SELECT id, title FROM milestone ORDER BY is_open DESC";
+	private static final String EXIST_BY_ID_SQL = "SELECT EXISTS(SELECT 1 FROM milestone WHERE is_deleted = false AND id = :id)";
+	private static final String FIND_ALL_FOR_FILTER = "SELECT id, title FROM milestone WHERE milestone.is_deleted = false ORDER BY is_open DESC";
 	private static final String SAVE_SQL = "INSERT INTO milestone(title, description, deadline, is_open) VALUE(:title, :description, :deadline, true)";
 	private static final String UPDATE_SQL = "UPDATE milestone SET title = :title, description = :description, deadline = :deadline WHERE id = :id";
 	private static final String UPDATE_OPEN_STATUS_SQL = "UPDATE milestone SET is_open = :isOpen WHERE id = :id";
@@ -37,7 +37,8 @@ public class JdbcMilestoneRepository implements MilestoneRepository {
 		+ "LEFT JOIN issue "
 		+ "ON milestone.id = issue.milestone_id "
 		+ "WHERE milestone.is_deleted = false "
-		+ "GROUP BY milestone.id";
+		+ "GROUP BY milestone.id "
+		+ "ORDER BY milestone.id DESC ";
 	private static final String FIND_ALL_ASSIGNED_TO_ISSUE
 		= "SELECT "
 		+ "    milestone.id, "
@@ -48,8 +49,10 @@ public class JdbcMilestoneRepository implements MilestoneRepository {
 		+ "FROM milestone "
 		+ "RIGHT JOIN issue "
 		+ "ON milestone.id = issue.milestone_id "
-		+ "WHERE milestone_id = (SELECT sub_issue.milestone_id FROM issue sub_issue WHERE sub_issue.id = :issueId) "
-		+ "GROUP BY milestone.id";
+		+ "WHERE milestone.is_deleted = false "
+		+ "AND milestone_id = (SELECT sub_issue.milestone_id FROM issue sub_issue WHERE sub_issue.id = :issueId) "
+		+ "GROUP BY milestone.id "
+		+ "ORDER BY milestone.title ";
 	private static final String FIND_ALL_UNASSIGNED_TO_ISSUE
 		= "SELECT "
 		+ "    milestone.id, "
@@ -60,8 +63,10 @@ public class JdbcMilestoneRepository implements MilestoneRepository {
 		+ "FROM milestone "
 		+ "LEFT JOIN issue "
 		+ "ON milestone.id = issue.milestone_id "
-		+ "WHERE milestone.id NOT IN (SELECT sub_issue.milestone_id FROM issue sub_issue WHERE sub_issue.id = :issueId) "
-		+ "GROUP BY milestone.id";
+		+ "WHERE milestone.is_deleted = false "
+		+ "AND milestone.id NOT IN (SELECT sub_issue.milestone_id FROM issue sub_issue WHERE sub_issue.id = :issueId) "
+		+ "GROUP BY milestone.id "
+		+ "ORDER BY milestone.title ";
 
 	private final NamedParameterJdbcTemplate jdbcTemplate;
 

--- a/BE/src/main/java/com/issuetracker/milestone/ui/MilestoneController.java
+++ b/BE/src/main/java/com/issuetracker/milestone/ui/MilestoneController.java
@@ -11,10 +11,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,6 +19,7 @@ import com.issuetracker.milestone.application.MilestoneService;
 import com.issuetracker.milestone.ui.dto.MilestoneCreateRequest;
 import com.issuetracker.milestone.ui.dto.MilestoneCreateResponse;
 import com.issuetracker.milestone.ui.dto.MilestoneDeleteRequest;
+import com.issuetracker.milestone.ui.dto.MilestoneSearchByOpenStatusRequest;
 import com.issuetracker.milestone.ui.dto.MilestoneUpdateOpenStatusRequest;
 import com.issuetracker.milestone.ui.dto.MilestoneUpdateRequest;
 import com.issuetracker.milestone.ui.dto.MilestonesResponse;
@@ -73,8 +70,11 @@ public class MilestoneController {
 	}
 
 	@GetMapping
-	public ResponseEntity<MilestonesResponse> showMilestones() {
+	public ResponseEntity<MilestonesResponse> showMilestones(
+		MilestoneSearchByOpenStatusRequest milestoneSearchByOpenStatusRequest) {
+
 		return ResponseEntity.ok()
-			.body(MilestonesResponse.from(milestoneService.search()));
+			.body(MilestonesResponse.from(milestoneService.search(
+				milestoneSearchByOpenStatusRequest.toMilestoneSearchByOpenStatusInputData())));
 	}
 }

--- a/BE/src/main/java/com/issuetracker/milestone/ui/dto/IssueDetailMilestoneResponse.java
+++ b/BE/src/main/java/com/issuetracker/milestone/ui/dto/IssueDetailMilestoneResponse.java
@@ -16,7 +16,7 @@ public class IssueDetailMilestoneResponse {
 
 	private Long id;
 	private String title;
-	private Double progress;
+	private Integer progress;
 
 	public static IssueDetailMilestoneResponse from(IssueDetailMilestoneInformation milestone) {
 		if (Objects.isNull(milestone)) {

--- a/BE/src/main/java/com/issuetracker/milestone/ui/dto/MilestoneCountMetadataResponse.java
+++ b/BE/src/main/java/com/issuetracker/milestone/ui/dto/MilestoneCountMetadataResponse.java
@@ -1,0 +1,29 @@
+package com.issuetracker.milestone.ui.dto;
+
+import com.issuetracker.milestone.application.dto.MilestoneCountMetadataInformation;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class MilestoneCountMetadataResponse {
+
+	private int totalLabelCount;
+	private int totalMilestoneCount;
+	private int openMilestoneCount;
+	private int closeMilestoneCount;
+
+	public static MilestoneCountMetadataResponse from(
+		MilestoneCountMetadataInformation metadataInformation) {
+		return new MilestoneCountMetadataResponse(
+			metadataInformation.getTotalLabelCount(),
+			metadataInformation.getTotalMilestoneCount(),
+			metadataInformation.getOpenMilestoneCount(),
+			metadataInformation.getCloseMilestoneCount()
+		);
+	}
+}

--- a/BE/src/main/java/com/issuetracker/milestone/ui/dto/MilestoneResponse.java
+++ b/BE/src/main/java/com/issuetracker/milestone/ui/dto/MilestoneResponse.java
@@ -23,7 +23,7 @@ public class MilestoneResponse {
 	private LocalDate deadline;
 	@JsonProperty(value = "isOpen")
 	private boolean open;
-	private Double progress;
+	private Integer progress;
 
 	public static MilestoneResponse from(MilestoneInformation milestoneInformation) {
 		return new MilestoneResponse(

--- a/BE/src/main/java/com/issuetracker/milestone/ui/dto/MilestoneSearchByOpenStatusRequest.java
+++ b/BE/src/main/java/com/issuetracker/milestone/ui/dto/MilestoneSearchByOpenStatusRequest.java
@@ -1,0 +1,57 @@
+package com.issuetracker.milestone.ui.dto;
+
+import javax.validation.constraints.Pattern;
+
+import com.issuetracker.config.exception.CustomHttpException;
+import com.issuetracker.config.exception.ErrorType;
+import com.issuetracker.milestone.application.dto.MilestoneSearchByOpenStatusInputData;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class MilestoneSearchByOpenStatusRequest {
+
+	private static final String TRUE_STRING = "true";
+	private static final String FALSE_STRING = "false";
+	private static final String NULL_STRING = "null";
+
+	@Pattern(regexp = "^(true|false)$", message = "마일스톤 열림 상태는 true 또는 false 값만 입력 가능합니다.")
+	private String isOpen;
+
+	public MilestoneSearchByOpenStatusInputData toMilestoneSearchByOpenStatusInputData() {
+		return new MilestoneSearchByOpenStatusInputData(
+			convertFrom(isOpen)
+		);
+	}
+
+	private static boolean convertFrom(String isOpenString) {
+		System.out.println(isOpenString);
+		if (isTrue(isOpenString)) {
+			return true;
+		} else if (isFalse(isOpenString)) {
+			return false;
+		} else if (isNull(isOpenString)) {
+			return true;
+		} else {
+			throw new CustomHttpException(ErrorType.ILLEGAL_BOOLEAN_VALUE);
+		}
+	}
+
+	private static boolean isTrue(String isOpenString) {
+		return TRUE_STRING.equalsIgnoreCase(isOpenString);
+	}
+
+	private static boolean isFalse(String isOpenString) {
+		return FALSE_STRING.equalsIgnoreCase(isOpenString);
+	}
+
+	private static boolean isNull(String isOpenString) {
+		return NULL_STRING.equalsIgnoreCase(isOpenString);
+	}
+}
+

--- a/BE/src/main/java/com/issuetracker/milestone/ui/dto/MilestonesResponse.java
+++ b/BE/src/main/java/com/issuetracker/milestone/ui/dto/MilestonesResponse.java
@@ -2,7 +2,7 @@ package com.issuetracker.milestone.ui.dto;
 
 import java.util.List;
 
-import com.issuetracker.milestone.application.dto.MilestoneInformation;
+import com.issuetracker.milestone.application.dto.MilestonesInformation;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -14,10 +14,14 @@ import lombok.NoArgsConstructor;
 @Getter
 public class MilestonesResponse {
 
+	private MilestoneCountMetadataResponse metadata;
 	private List<MilestoneResponse> milestones;
 
-	public static MilestonesResponse from(List<MilestoneInformation> milestoneInformations) {
-		return new MilestonesResponse(MilestoneResponse.from(milestoneInformations));
+	public static MilestonesResponse from(MilestonesInformation milestonesInformation) {
+		return new MilestonesResponse(
+			MilestoneCountMetadataResponse.from(milestonesInformation.getMetadata()),
+			MilestoneResponse.from(milestonesInformation.getMilestones())
+		);
 	}
 }
 

--- a/BE/src/main/resources/mapper/IssueMapper.xml
+++ b/BE/src/main/resources/mapper/IssueMapper.xml
@@ -34,6 +34,7 @@
         <id property="id" column="issue_comment_id" />
         <result property="content" column="issue_comment_content" />
         <result property="description" column="issue_comment_description" />
+        <result property="createAt" column="issue_comment_create_at"/>
         <association property="author" column="issue_comment_author" javaType="Member">
             <id property="id" column="issue_comment_author_id" />
             <result property="nickname" column="issue_comment_author_nickname" />

--- a/BE/src/test/java/com/issuetracker/acceptance/IssueAcceptanceTest.java
+++ b/BE/src/test/java/com/issuetracker/acceptance/IssueAcceptanceTest.java
@@ -22,6 +22,7 @@ import static com.issuetracker.util.steps.IssueSteps.이슈_작성_요청;
 import static com.issuetracker.util.steps.IssueSteps.이슈_제목_수정_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -124,7 +125,7 @@ public class IssueAcceptanceTest extends AcceptanceTest {
 			"제목",
 			"내용",
 			List.of(MEMBER1.getId()),
-			List.of(LABEL1.getId()),
+			List.of(LABEL2.getId(), LABEL7.getId()),
 			MILESTON1.getId()
 		);
 		var response = 이슈_작성_요청(issueCreateRequest);
@@ -529,10 +530,20 @@ public class IssueAcceptanceTest extends AcceptanceTest {
 		List<IssueSearchResponse> issueSearchResponses = findResponse.as(IssuesSearchResponse.class).getIssues();
 		IssueSearchResponse lastIssueSearchResponse = issueSearchResponses.get(0);
 
-		assertThat(lastIssueSearchResponse.getId()).isEqualTo(response.jsonPath().getLong("id"));
-		assertThat(lastIssueSearchResponse.getTitle()).isEqualTo(issueCreateRequest.getTitle());
-		assertThat(lastIssueSearchResponse.getIsOpen()).isTrue();
-		assertThat(lastIssueSearchResponse.getLabels().size()).isEqualTo(issueCreateRequest.getLabelIds().size());
+		Assertions.assertAll(
+			() -> assertThat(lastIssueSearchResponse.getId()).isEqualTo(response.jsonPath().getLong("id")),
+			() -> assertThat(lastIssueSearchResponse.getTitle()).isEqualTo(issueCreateRequest.getTitle()),
+			() -> assertThat(lastIssueSearchResponse.getIsOpen()).isTrue(),
+			() -> assertThat(lastIssueSearchResponse.getLabels()).hasSize(issueCreateRequest.getLabelIds().size()),
+			() -> {
+					if (Objects.isNull(issueCreateRequest.getMilestoneId())) {
+						assertThat(lastIssueSearchResponse.getMilestone()).isNull();
+						return;
+					}
+
+					assertThat(lastIssueSearchResponse.getMilestone().getId()).isEqualTo(issueCreateRequest.getMilestoneId());
+			}
+		);
 	}
 
 	private void 이슈_상세_조회_검증(ExtractableResponse<Response> response, IssueFixture issue) {

--- a/BE/src/test/java/com/issuetracker/acceptance/LabelAcceptanceTest.java
+++ b/BE/src/test/java/com/issuetracker/acceptance/LabelAcceptanceTest.java
@@ -3,6 +3,7 @@ package com.issuetracker.acceptance;
 import static com.issuetracker.util.steps.LabelSteps.*;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
@@ -235,7 +236,7 @@ public class LabelAcceptanceTest extends AcceptanceTest {
 		LabelCreateRequest labelCreateRequest) {
 		var findResponse = 레이블_목록_조회_요청();
 		List<LabelResponse> labelResponse = findResponse.as(LabelsResponse.class).getLabels();
-		LabelResponse lastLabelResponse = labelResponse.get(labelResponse.size() - 1);
+		LabelResponse lastLabelResponse = labelResponse.get(0);
 
 		SoftAssertions softAssertions = new SoftAssertions();
 		softAssertions.assertThat(lastLabelResponse.getId()).isEqualTo(response.jsonPath().getLong("id"));
@@ -248,7 +249,10 @@ public class LabelAcceptanceTest extends AcceptanceTest {
 		LabelUpdateRequest labelUpdateRequest, Long labelId) {
 		var findResponse = 레이블_목록_조회_요청();
 		List<LabelResponse> labelResponse = findResponse.as(LabelsResponse.class).getLabels();
-		LabelResponse lastLabelResponse = labelResponse.get(Long.valueOf(labelId - 1L).intValue());
+		LabelResponse lastLabelResponse = labelResponse.stream()
+			.filter(l -> Objects.equals(l.getId(), labelId))
+			.findAny()
+			.orElseThrow();
 
 		SoftAssertions softAssertions = new SoftAssertions();
 		softAssertions.assertThat(lastLabelResponse.getId()).isEqualTo(labelId);

--- a/BE/src/test/java/com/issuetracker/acceptance/MilestoneAcceptanceTest.java
+++ b/BE/src/test/java/com/issuetracker/acceptance/MilestoneAcceptanceTest.java
@@ -116,7 +116,7 @@ public class MilestoneAcceptanceTest extends AcceptanceTest {
 	@Test
 	void 마일스톤을_수정한다() {
 		// given
-		Long milestoneId = 1L;
+		Long milestoneId = 2L;
 		MilestoneUpdateRequest milestoneUpdateRequest = new MilestoneUpdateRequest(
 			"수정된 마일스톤 제목",
 			"수정된 마일스톤 설명",
@@ -139,7 +139,7 @@ public class MilestoneAcceptanceTest extends AcceptanceTest {
 	@Test
 	void 마일스톤을_수정시_제목이_공백이면_400에러를_반환한다() {
 		// given
-		Long milestoneId = 1L;
+		Long milestoneId = 2L;
 		MilestoneUpdateRequest milestoneUpdateRequest = new MilestoneUpdateRequest(
 			"",
 			"수정된 마일스톤 설명",
@@ -161,7 +161,7 @@ public class MilestoneAcceptanceTest extends AcceptanceTest {
 	@Test
 	void 마일스톤을_수정시_마일스톤_설명은_없어도_마일스톤을_수정한다() {
 		// given
-		Long milestoneId = 1L;
+		Long milestoneId = 2L;
 		MilestoneUpdateRequest milestoneUpdateRequest = new MilestoneUpdateRequest(
 			"수정된 마일스톤 제목",
 			null,
@@ -184,7 +184,7 @@ public class MilestoneAcceptanceTest extends AcceptanceTest {
 	@Test
 	void 마일스톤을_수정시_데드라인_형식이_올바르지_않으면_400에러를_반환한다() {
 		// given
-		Long milestoneId = 1L;
+		Long milestoneId = 2L;
 		MilestoneUpdateRequest milestoneUpdateRequest = new MilestoneUpdateRequest(
 			"수정된 마일스톤 제목",
 			"수정된 마일스톤 설명",
@@ -206,7 +206,7 @@ public class MilestoneAcceptanceTest extends AcceptanceTest {
 	@Test
 	void 마일스톤을_삭제한다() {
 		// given
-		Long milestoneId = 1L;
+		Long milestoneId = 2L;
 
 		// when
 		var response = 마일스톤_삭제_요청(milestoneId);
@@ -235,7 +235,7 @@ public class MilestoneAcceptanceTest extends AcceptanceTest {
 
 	private void 마일스톤_목록_조회_시_생성된_마일스톤을_검증(ExtractableResponse<Response> response,
 		MilestoneCreateRequest milestoneCreateRequest) {
-		var findResponse = 마일스톤_목록_조회_요청();
+		var findResponse = 열린_마일스톤_목록_조회_요청();
 		List<MilestoneResponse> milestoneResponse = findResponse.as(MilestonesResponse.class).getMilestones();
 		MilestoneResponse lastMilestoneResponse = milestoneResponse.get(0);
 
@@ -251,7 +251,7 @@ public class MilestoneAcceptanceTest extends AcceptanceTest {
 
 	private void 마일스톤_목록_조회_시_수정된_마일스톤을_검증(ExtractableResponse<Response> response,
 		MilestoneUpdateRequest milestoneUpdateRequest, Long milestoneId) {
-		var findResponse = 마일스톤_목록_조회_요청();
+		var findResponse = 열린_마일스톤_목록_조회_요청();
 		List<MilestoneResponse> milestoneResponse = findResponse.as(MilestonesResponse.class).getMilestones();
 		MilestoneResponse lastMilestoneResponse = milestoneResponse.stream()
 			.filter(m -> Objects.equals(m.getId(), milestoneId))
@@ -269,7 +269,7 @@ public class MilestoneAcceptanceTest extends AcceptanceTest {
 	}
 
 	private void 마일스톤_목록_조회_시_삭제된_마일스톤을_검증(ExtractableResponse<Response> response, Long milestoneId) {
-		var findResponse = 마일스톤_목록_조회_요청();
+		var findResponse = 열린_마일스톤_목록_조회_요청();
 		List<MilestoneResponse> milestoneResponses = findResponse.as(MilestonesResponse.class).getMilestones();
 
 		for (MilestoneResponse milestoneResponse : milestoneResponses) {

--- a/BE/src/test/java/com/issuetracker/acceptance/MilestoneAcceptanceTest.java
+++ b/BE/src/test/java/com/issuetracker/acceptance/MilestoneAcceptanceTest.java
@@ -3,6 +3,7 @@ package com.issuetracker.acceptance;
 import static com.issuetracker.util.steps.MilestoneSteps.*;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
@@ -236,7 +237,7 @@ public class MilestoneAcceptanceTest extends AcceptanceTest {
 		MilestoneCreateRequest milestoneCreateRequest) {
 		var findResponse = 마일스톤_목록_조회_요청();
 		List<MilestoneResponse> milestoneResponse = findResponse.as(MilestonesResponse.class).getMilestones();
-		MilestoneResponse lastMilestoneResponse = milestoneResponse.get(milestoneResponse.size() - 1);
+		MilestoneResponse lastMilestoneResponse = milestoneResponse.get(0);
 
 		SoftAssertions softAssertions = new SoftAssertions();
 		softAssertions.assertThat(lastMilestoneResponse.getId()).isEqualTo(response.jsonPath().getLong("id"));
@@ -252,7 +253,10 @@ public class MilestoneAcceptanceTest extends AcceptanceTest {
 		MilestoneUpdateRequest milestoneUpdateRequest, Long milestoneId) {
 		var findResponse = 마일스톤_목록_조회_요청();
 		List<MilestoneResponse> milestoneResponse = findResponse.as(MilestonesResponse.class).getMilestones();
-		MilestoneResponse lastMilestoneResponse = milestoneResponse.get(Long.valueOf(milestoneId - 1L).intValue());
+		MilestoneResponse lastMilestoneResponse = milestoneResponse.stream()
+			.filter(m -> Objects.equals(m.getId(), milestoneId))
+			.findAny()
+			.orElseThrow();
 
 		SoftAssertions softAssertions = new SoftAssertions();
 		softAssertions.assertThat(lastMilestoneResponse.getId()).isEqualTo(milestoneId);

--- a/BE/src/test/java/com/issuetracker/acceptance/MilestoneAcceptanceTest.java
+++ b/BE/src/test/java/com/issuetracker/acceptance/MilestoneAcceptanceTest.java
@@ -178,7 +178,7 @@ public class MilestoneAcceptanceTest extends AcceptanceTest {
 
 	/**
 	 * Given 마일스톤 제목, 마일스톤 설명, 마일스톤 데드라인을 생성하고
-	 * When 마일스톤을 수정시 데드라인이 yyyy.MM.dd 형식이 아니면
+	 * When 마일스톤을 수정시 데드라인이 yyyy-MM-dd 형식이 아니면
 	 * Then 400에러를 반환한다.
 	 */
 	@Test

--- a/BE/src/test/java/com/issuetracker/util/steps/MilestoneSteps.java
+++ b/BE/src/test/java/com/issuetracker/util/steps/MilestoneSteps.java
@@ -1,5 +1,7 @@
 package com.issuetracker.util.steps;
 
+import java.util.Map;
+
 import org.springframework.http.MediaType;
 
 import com.issuetracker.milestone.ui.dto.MilestoneCreateRequest;
@@ -11,8 +13,23 @@ import io.restassured.response.Response;
 
 public class MilestoneSteps {
 
-	public static ExtractableResponse<Response> 마일스톤_목록_조회_요청() {
+	public static ExtractableResponse<Response> 열린_마일스톤_목록_조회_요청() {
+
+		Map<String, Object> params = Map.of("isOpen", "true");
+
 		return RestAssured.given().log().all()
+			.queryParams(params)
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+			.when().get("/api/milestones")
+			.then().log().all().extract();
+	}
+
+	public static ExtractableResponse<Response> 닫힌_마일스톤_목록_조회_요청() {
+
+		Map<String, Object> params = Map.of("isOpen", "false");
+
+		return RestAssured.given().log().all()
+			.queryParams(params)
 			.accept(MediaType.APPLICATION_JSON_VALUE)
 			.when().get("/api/milestones")
 			.then().log().all().extract();


### PR DESCRIPTION
## Key changes 🔑
- CORS 추가
- 레이블 및 마일스톤 총 갯수 반환하는 쿼리 수정
- 레이블 및 마일스톤 총 갯수 반환 시 삭제된 경우는 갯수에 포함되지 않게 변경
- 레이블 및 마일스톤 목록 조회 정렬 수정
- 이슈 작성 시 레이블과 담당자가 없을 경우 요청이 실패되는 현상 수정
- 이슈 상세 조회 시 댓글 생성 날짜 null인 현상 수정
- 마일스톤 deadline 형식을 yyyy-MM-dd로 변경
-  마일스톤 생성 시 열림닫힌 상태값 추가하기
- 마일스톤 목록 조회 시 열림/닫힘 상태 구분하기
- 마일스톤 진행상황 정수로 변경하기
- 레이블 목록 반환시 메타데이터 추가
- 마일스톤 목록 반환시 메타데이터 추가
- 메타데이터 추가로 인한 테스트 변경