### PR TITLE
[BE] fix/#180 이슈 생성, 회원 정보 수정, 로깅 변경

### DIFF
--- a/BE/src/main/java/com/issuetracker/common/config/ErrorResponse.java
+++ b/BE/src/main/java/com/issuetracker/common/config/ErrorResponse.java
@@ -1,21 +1,17 @@
 package com.issuetracker.common.config;
 
-import org.springframework.http.HttpStatus;
+import com.issuetracker.common.config.exception.ErrorType;
 
-import lombok.AllArgsConstructor;
-
-@AllArgsConstructor
 public class ErrorResponse {
 
-	private HttpStatus status;
 	private String message;
 
-	public int getStatusCode() {
-		return status.value();
+	public ErrorResponse(String message) {
+		this.message = message;
 	}
 
-	public String getStatus() {
-		return status.getReasonPhrase();
+	public ErrorResponse(ErrorType errorType) {
+		this.message = errorType.getMessage();
 	}
 
 	public String getMessage() {

--- a/BE/src/main/java/com/issuetracker/common/config/exception/ErrorType.java
+++ b/BE/src/main/java/com/issuetracker/common/config/exception/ErrorType.java
@@ -9,29 +9,46 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorType {
 
+	// LABEL
 	LABEL_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 레이블이 존재하지 않습니다."),
-	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 멤버가 존재하지 않습니다."),
-	MILESTONE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 마일스톤이 존재하지 않습니다."),
-	ISSUE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이슈가 존재하지 않습니다."),
-	FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 파일을 찾을 수 없습니다."),
-	ISSUE_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이슈 댓글을 찾을 수 없습니다."),
-
-	QUERY_STRING_KEY_NOT_MATCH(HttpStatus.BAD_REQUEST, "올바른 QueryString Key가 아닙니다."),
-
-	ILLEGAL_ID(HttpStatus.BAD_REQUEST, "유효한 id값이 아닙니다."),
-	ILLEGAL_BOOLEAN_VALUE(HttpStatus.BAD_REQUEST, "유효한 boolean값이 아닙니다."),
-
-	FILE_UPLOAD_MAX_SIZE(HttpStatus.BAD_REQUEST, "이미지 파일 용량은 5MB 이하만 가능합니다."),
-	FILE_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "이미지 파일만 업로드 가능합니다."),
-	ISSUE_UPDATE_NULL(HttpStatus.BAD_REQUEST, "수정할 데이터가 존재하지 않습니다."),
-	ASSIGNEE_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 등록된 담당자입니다."),
-	ASSIGNED_LABEL_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 등록된 라벨입니다."),
-	QUERY_STRING_VALUE_NOT_MATCH(HttpStatus.BAD_REQUEST, "올바른 QueryString Value가 아닙니다."),
-	MILESTONE_TITLE_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 등록된 제목입니다."),
 	LABEL_TITLE_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 등록된 제목입니다."),
 
+	// MILESTONE
+	MILESTONE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 마일스톤이 존재하지 않습니다."),
+	MILESTONE_TITLE_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 등록된 제목입니다."),
+
+	// MEMBER
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 멤버가 존재하지 않습니다."),
 	ACCOUNT_EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 사용중인 email 입니다."),
-	NO_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "해당 리프레시 토큰이 존재하지 않습니다.");
+
+	// ASSIGNEE
+	ASSIGNEE_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 등록된 담당자입니다."),
+	ASSIGNED_LABEL_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 등록된 라벨입니다."),
+
+	// ISSUE
+	ISSUE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이슈가 존재하지 않습니다."),
+	ISSUE_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이슈 댓글을 찾을 수 없습니다."),
+	ISSUE_UPDATE_NULL(HttpStatus.BAD_REQUEST, "수정할 데이터가 존재하지 않습니다."),
+
+	// FILE
+	FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 파일을 찾을 수 없습니다."),
+	FILE_UPLOAD_MAX_SIZE(HttpStatus.BAD_REQUEST, "이미지 파일 용량은 5MB 이하만 가능합니다."),
+	FILE_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "이미지 파일만 업로드 가능합니다."),
+
+	// REQUEST
+	ILLEGAL_ID(HttpStatus.BAD_REQUEST, "유효한 id값이 아닙니다."),
+	ILLEGAL_BOOLEAN_VALUE(HttpStatus.BAD_REQUEST, "유효한 boolean값이 아닙니다."),
+	QUERY_STRING_KEY_NOT_MATCH(HttpStatus.BAD_REQUEST, "올바른 QueryString Key가 아닙니다."),
+	QUERY_STRING_VALUE_NOT_MATCH(HttpStatus.BAD_REQUEST, "올바른 QueryString Value가 아닙니다."),
+
+	// TOKEN
+	NO_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "해당 리프레시 토큰이 존재하지 않습니다."),
+	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "기한이 만료된 토큰입니다."),
+
+	// Exception
+	NO_HANDLER_FOUND(HttpStatus.NOT_FOUND, "해당 API 경로로는 요청할 수 없습니다."),
+	HTTP_MESSAGE_NOT_READABLE(HttpStatus.BAD_REQUEST, "JSON 필드 값은 String, Number, Array, Object 객체 또는 'null', 'true', 'false'만 입력 가능합니다."),
+	SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다");
 
 	private final HttpStatus status;
 	private final String message;

--- a/BE/src/main/java/com/issuetracker/common/config/filter/JwtAuthorizationFilter.java
+++ b/BE/src/main/java/com/issuetracker/common/config/filter/JwtAuthorizationFilter.java
@@ -1,5 +1,7 @@
 package com.issuetracker.common.config.filter;
 
+import static com.issuetracker.common.config.exception.ErrorType.EXPIRED_TOKEN;
+
 import java.io.IOException;
 
 import javax.servlet.Filter;
@@ -21,6 +23,7 @@ import org.springframework.util.PatternMatchUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.issuetracker.account.infrastructure.JwtTokenGenerator;
 import com.issuetracker.common.config.ErrorResponse;
+import com.issuetracker.common.config.exception.ErrorType;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -121,8 +124,8 @@ public class JwtAuthorizationFilter implements Filter {
 		response.getWriter().write(
 			objectMapper.writeValueAsString(
 				new ResponseEntity<ErrorResponse>(
-					new ErrorResponse(HttpStatus.UNAUTHORIZED, "기한이 만료된 토큰입니다."),
-					HttpStatus.UNAUTHORIZED
+					new ErrorResponse(EXPIRED_TOKEN),
+					EXPIRED_TOKEN.getStatus()
 				)
 			)
 		);
@@ -130,7 +133,7 @@ public class JwtAuthorizationFilter implements Filter {
 
 	private ResponseEntity<ErrorResponse> generateErrorApiResponse(RuntimeException e) {
 		return ResponseEntity.badRequest().body(
-			new ErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage())
+			new ErrorResponse(e.getMessage())
 		);
 	}
 

--- a/BE/src/main/java/com/issuetracker/issue/application/dto/assignedlabel/AssignedLabelCandidatesInformation.java
+++ b/BE/src/main/java/com/issuetracker/issue/application/dto/assignedlabel/AssignedLabelCandidatesInformation.java
@@ -27,7 +27,8 @@ public class AssignedLabelCandidatesInformation {
 		return new LabelInformation(
 			label.getId(),
 			label.getTitle(),
-			label.getColor(),
+			label.getBackgroundColor(),
+			label.getTextColor(),
 			label.getDescription()
 		);
 	}

--- a/BE/src/main/java/com/issuetracker/issue/infrastrucure/JdbcAssignedLabelRepository.java
+++ b/BE/src/main/java/com/issuetracker/issue/infrastrucure/JdbcAssignedLabelRepository.java
@@ -21,9 +21,9 @@ public class JdbcAssignedLabelRepository implements AssignedLabelRepository {
 
 	private static final String SAVE_SQL = "INSERT INTO assigned_label(issue_id, label_id) VALUES(:issueId, :labelId)";
 	private static final String DELETE_SQL = "DELETE FROM assigned_label WHERE id = :id";
-	private static final String FIND_ALL_SEARCH_SQL = "SELECT DISTINCT label.id, label.title, label.color, label.description FROM label INNER JOIN assigned_label ON label.id = assigned_label.label_id WHERE label.is_deleted = 0 ORDER BY label.id";
+	private static final String FIND_ALL_SEARCH_SQL = "SELECT DISTINCT label.id, label.title, label.background_color, label.text_color, label.description FROM label INNER JOIN assigned_label ON label.id = assigned_label.label_id WHERE label.is_deleted = 0 ORDER BY label.id";
 	private static final String FIND_ALL_ASSIGNED_TO_ISSUE
-		= "SELECT label.id, label.title, label.color, label.description "
+		= "SELECT label.id, label.title, label.background_color, label.text_color, label.description "
 		+ "FROM assigned_label "
 		+ "LEFT JOIN label "
 		+ "ON assigned_label.label_id = label.id "
@@ -31,7 +31,7 @@ public class JdbcAssignedLabelRepository implements AssignedLabelRepository {
 		+ "AND label.is_deleted = false "
 		+ "ORDER BY label.title ";
 	private static final String FIND_ALL_UNASSIGNED_TO_ISSUE
-		= "SELECT label.id, label.title, label.color, label.description "
+		= "SELECT label.id, label.title, label.background_color, label.text_color, label.description "
 		+ "FROM label "
 		+ "WHERE label.is_deleted = false "
 		+ "AND label.id NOT IN( "
@@ -86,7 +86,8 @@ public class JdbcAssignedLabelRepository implements AssignedLabelRepository {
 		Label.builder()
 			.id(rs.getLong("id"))
 			.title(rs.getString("title"))
-			.color(rs.getString("color"))
+			.backgroundColor(rs.getString("background_color"))
+			.textColor(rs.getString("text_color"))
 			.description(rs.getString("description"))
 			.build();
 }

--- a/BE/src/main/java/com/issuetracker/issue/ui/IssueController.java
+++ b/BE/src/main/java/com/issuetracker/issue/ui/IssueController.java
@@ -44,6 +44,7 @@ import com.issuetracker.issue.ui.dto.comment.IssueCommentCreateRequest;
 import com.issuetracker.issue.ui.dto.comment.IssueCommentCreateResponse;
 import com.issuetracker.issue.ui.dto.comment.IssueCommentUpdateRequest;
 import com.issuetracker.issue.ui.dto.milestone.MilestoneCandidatesResponse;
+import com.issuetracker.label.application.LabelService;
 import com.issuetracker.member.application.MemberService;
 import com.issuetracker.milestone.application.MilestoneService;
 import com.issuetracker.milestone.ui.dto.MilestonesSearchResponse;
@@ -61,6 +62,7 @@ public class IssueController {
 	private final AssigneeService assigneeService;
 	private final AssignedLabelService assignedLabelService;
 	private final IssueCommentService issueCommentService;
+	private final LabelService labelService;
 
 	@GetMapping
 	public ResponseEntity<IssuesSearchResponse> showIssues(IssueSearchRequest issueSearchRequest,
@@ -89,19 +91,19 @@ public class IssueController {
 
 	@GetMapping("/authors")
 	public ResponseEntity<AuthorResponses> showAuthors() {
-		return ResponseEntity.ok().body(AuthorResponses.from(memberService.searchAuthors()));
+		return ResponseEntity.ok().body(AuthorResponses.from(memberService.searchMember()));
 	}
 
 	@GetMapping("/assignees")
 	public ResponseEntity<AssigneesResponses> showAssignees() {
-		AssigneesResponses assigneesResponses = AssigneesResponses.from(assigneeService.searchAssignee());
+		AssigneesResponses assigneesResponses = AssigneesResponses.from(memberService.searchMember());
 		return ResponseEntity.ok().body(assigneesResponses);
 	}
 
 	@GetMapping("/labels")
 	public ResponseEntity<AssignedLabelResponses> showLabels() {
 		AssignedLabelResponses assignedLabelResponses = AssignedLabelResponses.from(
-			assignedLabelService.searchAssignedLabel());
+			labelService.searchOrderByTitle());
 		return ResponseEntity.ok().body(assignedLabelResponses);
 	}
 

--- a/BE/src/main/java/com/issuetracker/label/application/LabelService.java
+++ b/BE/src/main/java/com/issuetracker/label/application/LabelService.java
@@ -1,10 +1,10 @@
 package com.issuetracker.label.application;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.issuetracker.common.config.exception.CustomHttpException;
-import com.issuetracker.common.config.exception.ErrorType;
 import com.issuetracker.label.application.dto.LabelCountMetadataInformation;
 import com.issuetracker.label.application.dto.LabelCreateInformation;
 import com.issuetracker.label.application.dto.LabelCreateInputData;
@@ -49,5 +49,9 @@ public class LabelService {
 			LabelCountMetadataInformation.from(labelRepository.calculateMetadata()),
 			LabelInformation.from(labelRepository.findAll())
 		);
+	}
+
+	public List<LabelInformation> searchOrderByTitle() {
+		return LabelInformation.from(labelRepository.searchOrderByTitle());
 	}
 }

--- a/BE/src/main/java/com/issuetracker/label/application/dto/LabelCreateInputData.java
+++ b/BE/src/main/java/com/issuetracker/label/application/dto/LabelCreateInputData.java
@@ -1,5 +1,8 @@
 package com.issuetracker.label.application.dto;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
 import com.issuetracker.label.domain.Label;
 
 import lombok.Getter;
@@ -9,19 +12,22 @@ public class LabelCreateInputData {
 
 	private String title;
 	private String description;
-	private String color;
+	private String backgroundColor;
+	private String textColor;
 
-	public LabelCreateInputData(String title, String description, String color) {
+	public LabelCreateInputData(String title, String description, String backgroundColor, String textColor) {
 		this.title = title;
 		this.description = description;
-		this.color = color;
+		this.backgroundColor = backgroundColor;
+		this.textColor = textColor;
 	}
 
 	public Label toLabelForCreate() {
 		return Label.builder()
 			.title(title)
 			.description(description)
-			.color(color)
+			.backgroundColor(backgroundColor)
+			.textColor(textColor)
 			.build();
 	}
 }

--- a/BE/src/main/java/com/issuetracker/label/application/dto/LabelInformation.java
+++ b/BE/src/main/java/com/issuetracker/label/application/dto/LabelInformation.java
@@ -14,14 +14,16 @@ public class LabelInformation {
 
 	private Long id;
 	private String title;
-	private String color;
+	private String backgroundColor;
+	private String textColor;
 	private String description;
 
 	public static LabelInformation from(Label label) {
 		return new LabelInformation(
 			label.getId(),
 			label.getTitle(),
-			label.getColor(),
+			label.getBackgroundColor(),
+			label.getTextColor(),
 			label.getDescription()
 		);
 	}

--- a/BE/src/main/java/com/issuetracker/label/application/dto/LabelUpdateInputData.java
+++ b/BE/src/main/java/com/issuetracker/label/application/dto/LabelUpdateInputData.java
@@ -10,13 +10,15 @@ public class LabelUpdateInputData {
 	private Long id;
 	private String title;
 	private String description;
-	private String color;
+	private String backgroundColor;
+	private String textColor;
 
-	public LabelUpdateInputData(Long id, String title, String description, String color) {
+	public LabelUpdateInputData(Long id, String title, String description, String backgroundColor, String textColor) {
 		this.id = id;
 		this.title = title;
 		this.description = description;
-		this.color = color;
+		this.backgroundColor = backgroundColor;
+		this.textColor = textColor;
 	}
 
 	public Label toLabelForUpdate() {
@@ -24,7 +26,8 @@ public class LabelUpdateInputData {
 			.id(id)
 			.title(title)
 			.description(description)
-			.color(color)
+			.backgroundColor(backgroundColor)
+			.textColor(textColor)
 			.build();
 	}
 }

--- a/BE/src/main/java/com/issuetracker/label/domain/Label.java
+++ b/BE/src/main/java/com/issuetracker/label/domain/Label.java
@@ -12,14 +12,16 @@ public class Label {
 	private Long id;
 	private String title;
 	private String description;
-	private String color;
+	private String backgroundColor;
+	private String textColor;
 
 	@Builder
-	private Label(Long id, String title, String description, String color) {
+	public Label(Long id, String title, String description, String backgroundColor, String textColor) {
 		this.id = id;
 		this.title = title;
 		this.description = description;
-		this.color = color;
+		this.backgroundColor = backgroundColor;
+		this.textColor = textColor;
 	}
 
 	public boolean equalsId(Long id) {

--- a/BE/src/main/java/com/issuetracker/label/domain/LabelRepository.java
+++ b/BE/src/main/java/com/issuetracker/label/domain/LabelRepository.java
@@ -16,6 +16,8 @@ public interface LabelRepository {
 
 	List<Label> findAll();
 
+	List<Label> searchOrderByTitle();
+
 	boolean existById(Long id);
 
 	LabelCountMetadata calculateMetadata();

--- a/BE/src/main/java/com/issuetracker/label/infrastructure/JdbcLabelRepository.java
+++ b/BE/src/main/java/com/issuetracker/label/infrastructure/JdbcLabelRepository.java
@@ -26,6 +26,7 @@ public class JdbcLabelRepository implements LabelRepository {
 	private static final String UPDATE_SQL = "UPDATE label SET title = :title, description = :description, color = :color WHERE id = :id";
 	private static final String DELETE_SQL = "UPDATE label SET is_deleted = true WHERE id = :id";
 	private static final String FIND_ALL_SQL = "SELECT id, title, description, color FROM label WHERE is_deleted = false ORDER BY id desc";
+	private static final String FIND_ALL_SEARCH_SQL = "SELECT id, title, color, description FROM label WHERE label.is_deleted = 0 ORDER BY title";
 	private static final String CALCULATE_COUNT_METADATA
 		= "SELECT "
 		+ "    (SELECT COUNT(id) FROM label WHERE is_deleted = false) AS total_label_count, "
@@ -88,6 +89,11 @@ public class JdbcLabelRepository implements LabelRepository {
 	@Override
 	public List<Label> findAll() {
 		return jdbcTemplate.query(FIND_ALL_SQL, LABEL_ROW_MAPPER);
+	}
+
+	@Override
+	public List<Label> searchOrderByTitle() {
+		return jdbcTemplate.query(FIND_ALL_SEARCH_SQL, LABEL_ROW_MAPPER);
 	}
 
 	@Override

--- a/BE/src/main/java/com/issuetracker/label/infrastructure/JdbcLabelRepository.java
+++ b/BE/src/main/java/com/issuetracker/label/infrastructure/JdbcLabelRepository.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
@@ -22,11 +23,11 @@ public class JdbcLabelRepository implements LabelRepository {
 	private static final String EXIST_BY_ID_SQL = "SELECT EXISTS(SELECT 1 FROM label WHERE id = :id AND is_deleted = false)";
 	private static final String EXIST_BY_TITLE_SQL = "SELECT EXISTS(SELECT 1 FROM label WHERE is_deleted = false AND title = :title)";
 	private static final String EXIST_BY_IDS_SQL = "SELECT IF(COUNT(id) = :size, TRUE, FALSE) FROM label WHERE is_deleted = false AND id IN(:labelIds)";
-	private static final String SAVE_SQL = "INSERT INTO label(title, description, color) VALUE(:title, :description, :color)";
-	private static final String UPDATE_SQL = "UPDATE label SET title = :title, description = :description, color = :color WHERE id = :id";
+	private static final String SAVE_SQL = "INSERT INTO label(title, description, background_color, text_color) VALUE(:title, :description, :backgroundColor, :textColor)";
+	private static final String UPDATE_SQL = "UPDATE label SET title = :title, description = :description, background_color = :backgroundColor, text_color =:textColor WHERE id = :id";
 	private static final String DELETE_SQL = "UPDATE label SET is_deleted = true WHERE id = :id";
-	private static final String FIND_ALL_SQL = "SELECT id, title, description, color FROM label WHERE is_deleted = false ORDER BY id desc";
-	private static final String FIND_ALL_SEARCH_SQL = "SELECT id, title, color, description FROM label WHERE label.is_deleted = 0 ORDER BY title";
+	private static final String FIND_ALL_SQL = "SELECT id, title, description, background_color, text_color FROM label WHERE is_deleted = false ORDER BY id desc";
+	private static final String FIND_ALL_SEARCH_SQL = "SELECT id, title, background_color, text_color, description FROM label WHERE label.is_deleted = 0 ORDER BY title";
 	private static final String CALCULATE_COUNT_METADATA
 		= "SELECT "
 		+ "    (SELECT COUNT(id) FROM label WHERE is_deleted = false) AS total_label_count, "
@@ -58,10 +59,7 @@ public class JdbcLabelRepository implements LabelRepository {
 
 	@Override
 	public Long save(Label label) {
-		MapSqlParameterSource param = new MapSqlParameterSource()
-			.addValue("title", label.getTitle())
-			.addValue("description", label.getDescription())
-			.addValue("color", label.getColor());
+		SqlParameterSource param = new BeanPropertySqlParameterSource(label);
 		KeyHolder keyHolder = new GeneratedKeyHolder();
 
 		jdbcTemplate.update(SAVE_SQL, param, keyHolder);
@@ -70,12 +68,7 @@ public class JdbcLabelRepository implements LabelRepository {
 
 	@Override
 	public int update(Label label) {
-		MapSqlParameterSource param = new MapSqlParameterSource()
-			.addValue("id", label.getId())
-			.addValue("title", label.getTitle())
-			.addValue("description", label.getDescription())
-			.addValue("color", label.getColor());
-
+		SqlParameterSource param = new BeanPropertySqlParameterSource(label);
 		return jdbcTemplate.update(UPDATE_SQL, param);
 	}
 
@@ -106,7 +99,8 @@ public class JdbcLabelRepository implements LabelRepository {
 			.id(rs.getLong("id"))
 			.title(rs.getString("title"))
 			.description(rs.getString("description"))
-			.color(rs.getString("color"))
+			.backgroundColor(rs.getString("background_color"))
+			.textColor(rs.getString("text_color"))
 			.build();
 
 	private static final RowMapper<LabelCountMetadata> LABEL_METADATA_MAPPER = (rs, rowNum) ->

--- a/BE/src/main/java/com/issuetracker/label/ui/dto/LabelCreateRequest.java
+++ b/BE/src/main/java/com/issuetracker/label/ui/dto/LabelCreateRequest.java
@@ -26,13 +26,18 @@ public class LabelCreateRequest {
 
 	@NotBlank(message = "컬러는 필수 값 입니다.")
 	@Pattern(regexp = "^#[0-9A-Fa-f]{6}$", message = "올바른 컬러 형식이 아닙니다.")
-	private String color;
+	private String backgroundColor;
+
+	@NotBlank(message = "컬러는 필수 값 입니다.")
+	@Pattern(regexp = "^#[0-9A-Fa-f]{6}$", message = "올바른 컬러 형식이 아닙니다.")
+	private String textColor;
 
 	public LabelCreateInputData toLabelCreateInputData() {
 		return new LabelCreateInputData(
 			title,
 			description,
-			color
+			backgroundColor,
+			textColor
 		);
 	}
 }

--- a/BE/src/main/java/com/issuetracker/label/ui/dto/LabelResponse.java
+++ b/BE/src/main/java/com/issuetracker/label/ui/dto/LabelResponse.java
@@ -17,14 +17,16 @@ public class LabelResponse {
 
 	private Long id;
 	private String title;
-	private String color;
+	private String backgroundColor;
+	private String textColor;
 	private String description;
 
 	public static LabelResponse from(LabelInformation labelInformation) {
 		return new LabelResponse(
 			labelInformation.getId(),
 			labelInformation.getTitle(),
-			labelInformation.getColor(),
+			labelInformation.getBackgroundColor(),
+			labelInformation.getTextColor(),
 			labelInformation.getDescription()
 		);
 	}

--- a/BE/src/main/java/com/issuetracker/label/ui/dto/LabelUpdateRequest.java
+++ b/BE/src/main/java/com/issuetracker/label/ui/dto/LabelUpdateRequest.java
@@ -26,14 +26,19 @@ public class LabelUpdateRequest {
 
 	@NotBlank(message = "컬러는 필수 값 입니다.")
 	@Pattern(regexp = "^#[0-9A-Fa-f]{6}$", message = "올바른 컬러 형식이 아닙니다.")
-	private String color;
+	private String backgroundColor;
+
+	@NotBlank(message = "컬러는 필수 값 입니다.")
+	@Pattern(regexp = "^#[0-9A-Fa-f]{6}$", message = "올바른 컬러 형식이 아닙니다.")
+	private String textColor;
 
 	public LabelUpdateInputData toLabelUpdateInputData(Long id) {
 		return new LabelUpdateInputData(
 			id,
 			title,
 			description,
-			color
+			backgroundColor,
+			textColor
 		);
 	}
 }

--- a/BE/src/main/java/com/issuetracker/member/application/MemberService.java
+++ b/BE/src/main/java/com/issuetracker/member/application/MemberService.java
@@ -25,7 +25,7 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 	private final FileService fileService;
 
-	public List<MemberInformation> searchAuthors() {
+	public List<MemberInformation> searchMember() {
 		return MemberInformation.from(memberRepository.search());
 	}
 

--- a/BE/src/main/java/com/issuetracker/member/application/MemberService.java
+++ b/BE/src/main/java/com/issuetracker/member/application/MemberService.java
@@ -39,8 +39,10 @@ public class MemberService {
 	public void updateMember(MemberUpdateData memberUpdateData) {
 		Member member = memberRepository.findById(memberUpdateData.getId())
 			.orElseThrow(() -> new CustomHttpException(ErrorType.MEMBER_NOT_FOUND));
-		String profileUrl = getProfileUrl(member.getProfileImageUrl(), memberUpdateData.getMultipartFile());
-		memberRepository.update(memberUpdateData.toMember(profileUrl));
+		String profileImageUrl = getProfileUrl(member.getProfileImageUrl(), memberUpdateData.getMultipartFile());
+
+		member.update(memberUpdateData.getNickname(), memberUpdateData.getPassword(), profileImageUrl);
+		memberRepository.update(member);
 	}
 
 	private String getProfileUrl(String originProfileUrl, MultipartFile multipartFile) {

--- a/BE/src/main/java/com/issuetracker/member/application/dto/MemberUpdateData.java
+++ b/BE/src/main/java/com/issuetracker/member/application/dto/MemberUpdateData.java
@@ -15,13 +15,4 @@ public class MemberUpdateData {
 	private String nickname;
 	private String password;
 	private MultipartFile multipartFile;
-
-	public Member toMember(String profileUrl) {
-		return Member.builder()
-			.id(id)
-			.nickname(nickname)
-			.password(password)
-			.profileImageUrl(profileUrl)
-			.build();
-	}
 }

--- a/BE/src/main/java/com/issuetracker/member/domain/Member.java
+++ b/BE/src/main/java/com/issuetracker/member/domain/Member.java
@@ -1,5 +1,9 @@
 package com.issuetracker.member.domain;
 
+import java.util.Objects;
+
+import org.springframework.web.multipart.MultipartFile;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,5 +30,19 @@ public class Member {
 
 	public boolean equalsId(Long id) {
 		return this.id.equals(id);
+	}
+
+	public void update(String nickname, String password, String profileImageUrl) {
+		if (Objects.nonNull(nickname)) {
+			this.nickname = nickname;
+		}
+
+		if (Objects.nonNull(password)) {
+			this.password = password;
+		}
+
+		if (Objects.nonNull(profileImageUrl)) {
+			this.profileImageUrl = profileImageUrl;
+		}
 	}
 }

--- a/BE/src/main/java/com/issuetracker/member/infrastructure/JdbcMemberRepository.java
+++ b/BE/src/main/java/com/issuetracker/member/infrastructure/JdbcMemberRepository.java
@@ -22,7 +22,7 @@ public class JdbcMemberRepository implements MemberRepository {
 	private static final String EXIST_BY_ID_SQL = "SELECT EXISTS(SELECT 1 FROM member WHERE id = :id)";
 	private static final String EXIST_BY_IDS_SQL = "SELECT IF(COUNT(id) = :size, TRUE, FALSE) FROM member WHERE id IN(:memberIds)";
 	private static final String SEARCH_SQL = "SELECT id, nickname, profile_image_url FROM member ORDER BY nickname";
-	private static final String FIND_BY_ID_SQL = "SELECT id, nickname, profile_image_url FROM member WHERE id = :id";
+	private static final String FIND_BY_ID_SQL = "SELECT id, nickname, password, profile_image_url FROM member WHERE id = :id";
 	private static final String UPDATE_MEMBER_SQL = "UPDATE member SET nickname =:nickname, password = :password, profile_image_url = :profileImageUrl WHERE id =:id";
 
 	private final NamedParameterJdbcTemplate jdbcTemplate;
@@ -51,7 +51,7 @@ public class JdbcMemberRepository implements MemberRepository {
 
 	@Override
 	public Optional<Member> findById(Long id) {
-		List<Member> members = jdbcTemplate.query(FIND_BY_ID_SQL, Map.of("id", id), AUTHOR_ROW_MAPPER);
+		List<Member> members = jdbcTemplate.query(FIND_BY_ID_SQL, Map.of("id", id), MEMBER_ROW_MAPPER);
 		return Optional.ofNullable(DataAccessUtils.singleResult(members));
 	}
 
@@ -64,6 +64,14 @@ public class JdbcMemberRepository implements MemberRepository {
 	private static final RowMapper<Member> AUTHOR_ROW_MAPPER = (rs, rowNum) ->
 		Member.builder()
 			.id(rs.getLong("id"))
+			.nickname(rs.getString("nickname"))
+			.profileImageUrl(rs.getString("profile_image_url"))
+			.build();
+
+	private static final RowMapper<Member> MEMBER_ROW_MAPPER = (rs, rowNum) ->
+		Member.builder()
+			.id(rs.getLong("id"))
+			.password(rs.getString("password"))
 			.nickname(rs.getString("nickname"))
 			.profileImageUrl(rs.getString("profile_image_url"))
 			.build();

--- a/BE/src/main/java/com/issuetracker/member/infrastructure/JdbcMemberRepository.java
+++ b/BE/src/main/java/com/issuetracker/member/infrastructure/JdbcMemberRepository.java
@@ -21,7 +21,7 @@ public class JdbcMemberRepository implements MemberRepository {
 
 	private static final String EXIST_BY_ID_SQL = "SELECT EXISTS(SELECT 1 FROM member WHERE id = :id)";
 	private static final String EXIST_BY_IDS_SQL = "SELECT IF(COUNT(id) = :size, TRUE, FALSE) FROM member WHERE id IN(:memberIds)";
-	private static final String SEARCH_SQL = "SELECT DISTINCT member.id, member.nickname, member.profile_image_url FROM issue JOIN member ON issue.author_id = member.id";
+	private static final String SEARCH_SQL = "SELECT id, nickname, profile_image_url FROM member ORDER BY nickname";
 	private static final String FIND_BY_ID_SQL = "SELECT id, nickname, profile_image_url FROM member WHERE id = :id";
 	private static final String UPDATE_MEMBER_SQL = "UPDATE member SET nickname =:nickname, password = :password, profile_image_url = :profileImageUrl WHERE id =:id";
 

--- a/BE/src/main/java/com/issuetracker/milestone/infrastructure/JdbcMilestoneRepository.java
+++ b/BE/src/main/java/com/issuetracker/milestone/infrastructure/JdbcMilestoneRepository.java
@@ -22,7 +22,7 @@ public class JdbcMilestoneRepository implements MilestoneRepository {
 
 	private static final String EXIST_BY_ID_SQL = "SELECT EXISTS(SELECT 1 FROM milestone WHERE is_deleted = false AND id = :id)";
 	private static final String EXIST_BY_TITLE_SQL = "SELECT EXISTS(SELECT 1 FROM milestone WHERE is_deleted = false AND title = :title)";
-	private static final String FIND_ALL_FOR_FILTER = "SELECT milestone.id, milestone.title FROM milestone INNER JOIN issue ON issue.milestone_id = milestone.id WHERE milestone.is_deleted = false GROUP BY milestone.id ORDER BY milestone.title DESC";
+	private static final String FIND_ALL_FOR_FILTER = "SELECT id, title FROM milestone WHERE milestone.is_deleted = false  ORDER BY title";
 	private static final String SAVE_SQL = "INSERT INTO milestone(title, description, deadline, is_open) VALUE(:title, :description, :deadline, true)";
 	private static final String UPDATE_SQL = "UPDATE milestone SET title = :title, description = :description, deadline = :deadline WHERE id = :id";
 	private static final String UPDATE_OPEN_STATUS_SQL = "UPDATE milestone SET is_open = :isOpen WHERE id = :id";

--- a/BE/src/main/resources/logback-spring.xml
+++ b/BE/src/main/resources/logback-spring.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
+    <property name="LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+
+    <springProfile name="!prod">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./log/info/info-${BY_DATE}.log</file>
+            <filter class = "ch.qos.logback.classic.filter.LevelFilter">
+                <level>INFO</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern> ./backup/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>100MB</maxFileSize>
+                <maxHistory>10</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <appender name="FILE-WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./log/warn/warn-${BY_DATE}.log</file>
+            <filter class = "ch.qos.logback.classic.filter.LevelFilter">
+                <level>WARN</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern> ./backup/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>100MB</maxFileSize>
+                <maxHistory>10</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./log/error/error-${BY_DATE}.log</file>
+            <filter class = "ch.qos.logback.classic.filter.LevelFilter">
+                <level>ERROR</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern> ./backup/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>100MB</maxFileSize>
+                <maxHistory>10</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="FILE-INFO"/>
+            <appender-ref ref="FILE-WARN"/>
+            <appender-ref ref="FILE-ERROR"/>
+        </root>
+    </springProfile>
+
+</configuration>

--- a/BE/src/main/resources/mapper/IssueMapper.xml
+++ b/BE/src/main/resources/mapper/IssueMapper.xml
@@ -25,7 +25,8 @@
         <collection property="labels" ofType="Label">
             <id property="id" column="label_id" />
             <result property="title" column="label_title" />
-            <result property="color" column="label_color" />
+            <result property="backgroundColor" column="label_background_color" />
+            <result property="textColor" column="label_text_color" />
             <result property="description" column="label_description" />
         </collection>
 
@@ -79,7 +80,8 @@
         <collection property="labels" ofType="Label">
             <id property="id" column="label_id" />
             <result property="title" column="label_title" />
-            <result property="color" column="label_color" />
+            <result property="backgroundColor" column="label_background_color" />
+            <result property="textColor" column="label_text_color" />
             <result property="description" column="label_description" />
         </collection>
     </resultMap>
@@ -97,7 +99,8 @@
                 milestone.title as milestone_title,
                 label.id as label_id,
                 label.title as label_title,
-                label.color as label_color,
+                label.background_color as label_background_color,
+                label.text_color as label_text_color,
                 label.description as label_description,
                 member.id as assignees_id,
                 member.nickname as assignees_nickname,
@@ -194,7 +197,8 @@
                         milestone.progress as milestone_progress,
                         label.id as label_id,
                         label.title as label_title,
-                        label.color as label_color,
+                        label.background_color as label_background_color,
+                        label.text_color as label_text_color,
                         label.description as label_description,
                         member.id as assignees_id,
                         member.nickname as assignees_nickname,

--- a/BE/src/test/java/com/issuetracker/acceptance/AssignedLabelAcceptanceTest.java
+++ b/BE/src/test/java/com/issuetracker/acceptance/AssignedLabelAcceptanceTest.java
@@ -25,21 +25,6 @@ import io.restassured.response.Response;
 public class AssignedLabelAcceptanceTest extends AcceptanceTest {
 
 	/**
-	 * Given 라벨, 이슈, 라벨과 이슈를 매핑하여 생성하고
-	 * When 이슈에 등록 되어있는 라벨 목록을 조회하면
-	 * Then 이슈에 등록 되어 있는 라벨 목록을 조회할 수 있다.
-	 */
-	@Test
-	void 라벨_목록을_조회한다() {
-		// when
-		var response = 이슈에_등록_되어있는_라벨_목록_조회_요청();
-
-		// then
-		응답_상태코드_검증(response, HttpStatus.OK);
-		이슈에_등록_되어있는_라벨_목록_검증(response);
-	}
-
-	/**
 	 * Given 회원, 라벨, 이슈를 생성하고
 	 * When 해당 이슈에 라벨을 등록하면
 	 * Then 등록 및 삭제될 라벨 목록에서 등록된 라벨을 찾을 수 있다.
@@ -127,11 +112,5 @@ public class AssignedLabelAcceptanceTest extends AcceptanceTest {
 		List<Long> labelIds = 이슈에_등록_및_삭제될_라벨_목록_조회_요청(id).jsonPath().getList("assignedLabels.id", Long.class);
 
 		assertThat(labelIds).contains(labelId);
-	}
-
-	private void 이슈에_등록_되어있는_라벨_목록_검증(ExtractableResponse<Response> response) {
-		List<Long> ids = response.jsonPath().getList("labels.id", Long.class);
-
-		assertThat(ids).containsExactly(3L, 4L, 5L, 7L);
 	}
 }

--- a/BE/src/test/java/com/issuetracker/acceptance/LabelAcceptanceTest.java
+++ b/BE/src/test/java/com/issuetracker/acceptance/LabelAcceptanceTest.java
@@ -1,9 +1,7 @@
 package com.issuetracker.acceptance;
 
 import static com.issuetracker.util.fixture.LabelFixture.LABEL1;
-import static com.issuetracker.util.fixture.MilestoneFixture.MILESTON1;
 import static com.issuetracker.util.steps.LabelSteps.*;
-import static com.issuetracker.util.steps.MilestoneSteps.마일스톤_생성_요청;
 
 import java.util.List;
 import java.util.Objects;
@@ -17,7 +15,6 @@ import com.issuetracker.label.ui.dto.LabelCreateRequest;
 import com.issuetracker.label.ui.dto.LabelResponse;
 import com.issuetracker.label.ui.dto.LabelUpdateRequest;
 import com.issuetracker.label.ui.dto.LabelsResponse;
-import com.issuetracker.milestone.ui.dto.MilestoneCreateRequest;
 import com.issuetracker.util.AcceptanceTest;
 
 import io.restassured.response.ExtractableResponse;
@@ -36,6 +33,7 @@ public class LabelAcceptanceTest extends AcceptanceTest {
 		LabelCreateRequest labelCreateRequest = new LabelCreateRequest(
 			"레이블 제목",
 			"레이블 설명",
+			"#ffffff",
 			"#ffffff"
 		);
 
@@ -58,6 +56,7 @@ public class LabelAcceptanceTest extends AcceptanceTest {
 		LabelCreateRequest labelCreateRequest = new LabelCreateRequest(
 			"",
 			"레이블 설명",
+			"#ffffff",
 			"#ffffff"
 		);
 
@@ -79,6 +78,7 @@ public class LabelAcceptanceTest extends AcceptanceTest {
 		LabelCreateRequest labelCreateRequest = new LabelCreateRequest(
 			"레이블 제목",
 			null,
+			"#ffffff",
 			"#ffffff"
 		);
 
@@ -101,7 +101,8 @@ public class LabelAcceptanceTest extends AcceptanceTest {
 		LabelCreateRequest labelCreateRequest = new LabelCreateRequest(
 			"레이블 제목",
 			"레이블 설명",
-			"#HEX코드가아니다"
+			"#HEX코드가아니다",
+			"#ffffff"
 		);
 
 		// when
@@ -121,6 +122,7 @@ public class LabelAcceptanceTest extends AcceptanceTest {
 		LabelCreateRequest labelCreateRequest = new LabelCreateRequest(
 			LABEL1.getTitle(),
 			"레이블 설명",
+			"#ffffff",
 			"#ffffff"
 		);
 
@@ -143,7 +145,8 @@ public class LabelAcceptanceTest extends AcceptanceTest {
 		LabelUpdateRequest labelUpdateRequest = new LabelUpdateRequest(
 			"수정된 레이블 제목",
 			"수정된 레이블 설명",
-			"#000000"
+			"#000000",
+			"#ffffff"
 		);
 
 		// when
@@ -166,7 +169,8 @@ public class LabelAcceptanceTest extends AcceptanceTest {
 		LabelUpdateRequest labelUpdateRequest = new LabelUpdateRequest(
 			"",
 			"수정된 레이블 설명",
-			"#000000"
+			"#000000",
+			"#ffffff"
 		);
 
 		// when
@@ -188,7 +192,8 @@ public class LabelAcceptanceTest extends AcceptanceTest {
 		LabelUpdateRequest labelUpdateRequest = new LabelUpdateRequest(
 			"수정된 레이블 제목",
 			null,
-			"#000000"
+			"#000000",
+			"#ffffff"
 		);
 
 		// when
@@ -211,7 +216,8 @@ public class LabelAcceptanceTest extends AcceptanceTest {
 		LabelUpdateRequest labelUpdateRequest = new LabelUpdateRequest(
 			"수정된 레이블 제목",
 			"수정된 레이블 설명",
-			"#HEX코드가아니다"
+			"#HEX코드가아니다",
+			"#ffffff"
 		);
 
 		// when
@@ -265,7 +271,8 @@ public class LabelAcceptanceTest extends AcceptanceTest {
 		SoftAssertions softAssertions = new SoftAssertions();
 		softAssertions.assertThat(lastLabelResponse.getId()).isEqualTo(response.jsonPath().getLong("id"));
 		softAssertions.assertThat(lastLabelResponse.getTitle()).isEqualTo(labelCreateRequest.getTitle());
-		softAssertions.assertThat(lastLabelResponse.getColor()).isEqualTo(labelCreateRequest.getColor());
+		softAssertions.assertThat(lastLabelResponse.getTextColor()).isEqualTo(labelCreateRequest.getTextColor());
+		softAssertions.assertThat(lastLabelResponse.getBackgroundColor()).isEqualTo(labelCreateRequest.getBackgroundColor());
 		softAssertions.assertAll();
 	}
 
@@ -281,7 +288,8 @@ public class LabelAcceptanceTest extends AcceptanceTest {
 		SoftAssertions softAssertions = new SoftAssertions();
 		softAssertions.assertThat(lastLabelResponse.getId()).isEqualTo(labelId);
 		softAssertions.assertThat(lastLabelResponse.getTitle()).isEqualTo(labelUpdateRequest.getTitle());
-		softAssertions.assertThat(lastLabelResponse.getColor()).isEqualTo(labelUpdateRequest.getColor());
+		softAssertions.assertThat(lastLabelResponse.getTextColor()).isEqualTo(labelUpdateRequest.getTextColor());
+		softAssertions.assertThat(lastLabelResponse.getBackgroundColor()).isEqualTo(labelUpdateRequest.getBackgroundColor());
 		softAssertions.assertAll();
 	}
 

--- a/BE/src/test/java/com/issuetracker/acceptance/MemberAcceptanceTest.java
+++ b/BE/src/test/java/com/issuetracker/acceptance/MemberAcceptanceTest.java
@@ -25,6 +25,7 @@ import com.issuetracker.file.application.FileService;
 import com.issuetracker.file.application.dto.FileMetadata;
 import com.issuetracker.member.ui.dto.MemberResponse;
 import com.issuetracker.util.AcceptanceTest;
+import com.issuetracker.util.fixture.MemberFixture;
 
 import io.restassured.builder.MultiPartSpecBuilder;
 import io.restassured.response.ExtractableResponse;
@@ -86,7 +87,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
 		// then
 		응답_상태코드_검증(response, HttpStatus.NO_CONTENT);
-		회원_정보를_조회하여_수정된_회원_정보_검증(MEMBER1.getId(), nickname, multiPartSpecification, MEMBER1.getProFileImageUrl());
+		회원_정보를_조회하여_수정된_회원_정보_검증(MEMBER1, nickname, multiPartSpecification);
 	}
 
 	/**
@@ -123,24 +124,45 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 				"test",
 				"password2",
 				null
+			),
+			Arguments.of(
+				null,
+				"password2",
+				null
+			),
+			Arguments.of(
+				"test",
+				null,
+				null
+			),
+			Arguments.of(
+				null,
+				null,
+				null
 			)
 		);
 	}
 
-	private void 회원_정보를_조회하여_수정된_회원_정보_검증(Long id, String nickname, MultiPartSpecification multiPartSpecification,
-		String profileImageUrl) {
-		MemberResponse memberResponse = 회원_정보_조회_요청(id).as(MemberResponse.class);
+	private void 회원_정보를_조회하여_수정된_회원_정보_검증(MemberFixture memberFixture, String nickname, MultiPartSpecification multiPartSpecification) {
+		MemberResponse memberResponse = 회원_정보_조회_요청(memberFixture.getId()).as(MemberResponse.class);
 
 		Assertions.assertAll(
-			() -> assertThat(memberResponse.getId()).isEqualTo(id),
-			() -> assertThat(memberResponse.getNickname()).isEqualTo(nickname),
+			() -> assertThat(memberResponse.getId()).isEqualTo(memberFixture.getId()),
 			() -> {
-				if (Objects.isNull(multiPartSpecification)) {
-					assertThat(memberResponse.getProfileImageUrl()).isEqualTo(profileImageUrl);
+				if (Objects.isNull(nickname)) {
+					assertThat(memberResponse.getNickname()).isEqualTo(memberFixture.getNickname());
 					return;
 				}
 
-				assertThat(memberResponse.getProfileImageUrl()).isNotEqualTo(profileImageUrl);
+				assertThat(memberResponse.getNickname()).isEqualTo(nickname);
+			},
+			() -> {
+				if (Objects.isNull(multiPartSpecification)) {
+					assertThat(memberResponse.getProfileImageUrl()).isEqualTo(memberFixture.getProFileImageUrl());
+					return;
+				}
+
+				assertThat(memberResponse.getProfileImageUrl()).isNotEqualTo(memberFixture.getProFileImageUrl());
 			}
 		);
 	}

--- a/BE/src/test/java/com/issuetracker/unit/infrastrucure/LabelJdbcRepositoryTest.java
+++ b/BE/src/test/java/com/issuetracker/unit/infrastrucure/LabelJdbcRepositoryTest.java
@@ -52,7 +52,8 @@ class LabelJdbcRepositoryTest extends JdbcRepositoryTest {
 			.id(1L)
 			.title("수정된 제목")
 			.description("수정된 설명")
-			.color("#000000")
+			.backgroundColor("#000000")
+			.textColor("#000000")
 			.build();
 
 		// when

--- a/BE/src/test/java/com/issuetracker/unit/infrastrucure/MilestoneJdbcRepositoryTest.java
+++ b/BE/src/test/java/com/issuetracker/unit/infrastrucure/MilestoneJdbcRepositoryTest.java
@@ -37,7 +37,7 @@ class MilestoneJdbcRepositoryTest extends JdbcRepositoryTest {
 	}
 
 	@Test
-	void 필터용_마일스톤_목록을_조회할_수_있다() {
+	void 마일스톤_목록을_조회할_수_있다() {
 		// when
 		List<Milestone> milestones = milestoneRepository.findAllForFilter();
 

--- a/BE/src/test/java/com/issuetracker/util/fixture/LabelFixture.java
+++ b/BE/src/test/java/com/issuetracker/util/fixture/LabelFixture.java
@@ -5,24 +5,26 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public enum LabelFixture {
-	LABEL1(1L, "style", "layout, style 등 수정", "#fbca04"),
-	LABEL2(2L, "bug fix", "Something working", "#d73a4a"),
-	LABEL3(3L, "docs", "Improvements or additions to documentation", "#0075ca"),
-	LABEL4(4L, "feature", "New feature", "#a2eeef"),
-	LABEL5(5L, "infra", "인프라 환경 설정", "#0315EB"),
-	LABEL6(6L, "refactor", "코드 리팩토링", "#23B63C"),
-	LABEL7(7L, "test", "테스트 코드", "#0e8a16");
+	LABEL1(1L, "style", "layout, style 등 수정", "#fbca04", "#000000"),
+	LABEL2(2L, "bug fix", "Something working", "#d73a4a", "#000000"),
+	LABEL3(3L, "docs", "Improvements or additions to documentation", "#0075ca", "#000000"),
+	LABEL4(4L, "feature", "New feature", "#a2eeef", "#000000"),
+	LABEL5(5L, "infra", "인프라 환경 설정", "#0315EB", "#000000"),
+	LABEL6(6L, "refactor", "코드 리팩토링", "#23B63C", "#000000"),
+	LABEL7(7L, "test", "테스트 코드", "#0e8a16", "#000000");
 
 	private final Long id;
 	private final String title;
 	private final String description;
-	private final String color;
+	private final String backgroundColor;
+	private final String textColor;
 
-	LabelFixture(Long id, String title, String description, String color) {
+	LabelFixture(Long id, String title, String description, String backgroundColor, String textColor) {
 		this.id = id;
 		this.title = title;
 		this.description = description;
-		this.color = color;
+		this.backgroundColor = backgroundColor;
+		this.textColor = textColor;
 	}
 
 	public Long getId() {
@@ -37,8 +39,12 @@ public enum LabelFixture {
 		return description;
 	}
 
-	public String getColor() {
-		return color;
+	public String getBackgroundColor() {
+		return backgroundColor;
+	}
+
+	public String getTextColor() {
+		return textColor;
 	}
 
 	public static LabelFixture findById(Long id) {
@@ -69,11 +75,12 @@ public enum LabelFixture {
 	}
 
 	public static String createInsertSQL() {
-		return String.format("INSERT INTO label(title, description, color) VALUES %s", Arrays.stream(values())
-			.map(l -> String.format("('%s', '%s', '%s')",
+		return String.format("INSERT INTO label(title, description, background_color, text_color) VALUES %s", Arrays.stream(values())
+			.map(l -> String.format("('%s', '%s', '%s', '%s')",
 				l.getTitle(),
 				l.getDescription(),
-				l.getColor()))
+				l.getBackgroundColor(),
+				l.getTextColor()))
 			.collect(Collectors.joining(", ")));
 	}
 }

--- a/BE/src/test/resources/schema.sql
+++ b/BE/src/test/resources/schema.sql
@@ -43,11 +43,12 @@ CREATE TABLE assigned_label (
 )ENGINE=memory;
 
 CREATE TABLE label (
-   id           bigint        NOT NULL AUTO_INCREMENT,
-   title        varchar(50)   NOT NULL,
-   description  varchar(100)  DEFAULT NULL,
-   color        varchar(7)    NOT NULL,
-   is_deleted     tinyint(1)  NOT NULL DEFAULT 0,
+   id               bigint        NOT NULL AUTO_INCREMENT,
+   title            varchar(50)   NOT NULL,
+   description      varchar(100)  DEFAULT NULL,
+   background_color varchar(7)    NOT NULL,
+   text_color       varchar(7)    NOT NULL,
+   is_deleted       tinyint(1)    NOT NULL DEFAULT 0,
    PRIMARY KEY (id)
 )ENGINE=memory;
 


### PR DESCRIPTION
## Key changes 🔑
- 이슈 생성 시 라벨, 마일스톤, 회원 전부 조회 (필터 조회 시 공통 코드로 사용)
- 회원 정보 수정시 nickname, password null 일 경우 기존 값 들어가게 변경
- 라벨에서 텍스트 색상, 배경 색상 추가
- 에러 코드 리팩토링